### PR TITLE
feat(config): add ability to configure widget outside of Widget instantiation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2424,14 +2424,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.16.tgz",
       "integrity": "sha512-BUuWMlt4WSXod1HSl7aGK8fJOsi+Tab/M0IDK1V1/GstzoOpqc/v3DqmN8MkuapPKQ9Br1WtLAN4uEgWR8x64A==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "dev": true,
       "optional": true,
-      "os": [
-        "android"
-      ],
+      "os": ["android"],
       "engines": {
         "node": ">=12"
       }
@@ -2440,14 +2436,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.16.tgz",
       "integrity": "sha512-hFHVAzUKp9Tf8psGq+bDVv+6hTy1bAOoV/jJMUWwhUnIHsh6WbFMhw0ZTkqDuh7TdpffFoHOiIOIxmHc7oYRBQ==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "android"
-      ],
+      "os": ["android"],
       "engines": {
         "node": ">=12"
       }
@@ -2456,14 +2448,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.16.tgz",
       "integrity": "sha512-9WhxJpeb6XumlfivldxqmkJepEcELekmSw3NkGrs+Edq6sS5KRxtUBQuKYDD7KqP59dDkxVbaoPIQFKWQG0KLg==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "android"
-      ],
+      "os": ["android"],
       "engines": {
         "node": ">=12"
       }
@@ -2472,14 +2460,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.16.tgz",
       "integrity": "sha512-8Z+wld+vr/prHPi2O0X7o1zQOfMbXWGAw9hT0jEyU/l/Yrg+0Z3FO9pjPho72dVkZs4ewZk0bDOFLdZHm8jEfw==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": ">=12"
       }
@@ -2488,14 +2472,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.16.tgz",
       "integrity": "sha512-CYkxVvkZzGCqFrt7EgjFxQKhlUPyDkuR9P0Y5wEcmJqVI8ncerOIY5Kej52MhZyzOBXkYrJgZeVZC9xXXoEg9A==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": ">=12"
       }
@@ -2504,14 +2484,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.16.tgz",
       "integrity": "sha512-fxrw4BYqQ39z/3Ja9xj/a1gMsVq0xEjhSyI4a9MjfvDDD8fUV8IYliac96i7tzZc3+VytyXX+XNsnpEk5sw5Wg==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "os": ["freebsd"],
       "engines": {
         "node": ">=12"
       }
@@ -2520,14 +2496,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.16.tgz",
       "integrity": "sha512-8p3v1D+du2jiDvSoNVimHhj7leSfST9YlKsAEO7etBfuqjaBMndo0fmjNLp0JCMld+XIx9L80tooOkyUv1a1PQ==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "os": ["freebsd"],
       "engines": {
         "node": ">=12"
       }
@@ -2536,14 +2508,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.16.tgz",
       "integrity": "sha512-bYaocE1/PTMRmkgSckZ0D0Xn2nox8v2qlk+MVVqm+VECNKDdZvghVZtH41dNtBbwADSvA6qkCHGYeWm9LrNCBw==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -2552,14 +2520,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.16.tgz",
       "integrity": "sha512-N3u6BBbCVY3xeP2D8Db7QY8I+nZ+2AgOopUIqk+5yCoLnsWkcVxD2ay5E9iIdvApFi1Vg1lZiiwaVp8bOpAc4A==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -2568,14 +2532,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.16.tgz",
       "integrity": "sha512-dxjqLKUW8GqGemoRT9v8IgHk+T4tRm1rn1gUcArsp26W9EkK/27VSjBVUXhEG5NInHZ92JaQ3SSMdTwv/r9a2A==",
-      "cpu": [
-        "ia32"
-      ],
+      "cpu": ["ia32"],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -2584,14 +2544,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.16.tgz",
       "integrity": "sha512-MdUFggHjRiCCwNE9+1AibewoNq6wf94GLB9Q9aXwl+a75UlRmbRK3h6WJyrSGA6ZstDJgaD2wiTSP7tQNUYxwA==",
-      "cpu": [
-        "loong64"
-      ],
+      "cpu": ["loong64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -2600,14 +2556,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.16.tgz",
       "integrity": "sha512-CO3YmO7jYMlGqGoeFeKzdwx/bx8Vtq/SZaMAi+ZLDUnDUdfC7GmGwXzIwDJ70Sg+P9pAemjJyJ1icKJ9R3q/Fg==",
-      "cpu": [
-        "mips64el"
-      ],
+      "cpu": ["mips64el"],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -2616,14 +2568,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.16.tgz",
       "integrity": "sha512-DSl5Czh5hCy/7azX0Wl9IdzPHX2H8clC6G87tBnZnzUpNgRxPFhfmArbaHoAysu4JfqCqbB/33u/GL9dUgCBAw==",
-      "cpu": [
-        "ppc64"
-      ],
+      "cpu": ["ppc64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -2632,14 +2580,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.16.tgz",
       "integrity": "sha512-sSVVMEXsqf1fQu0j7kkhXMViroixU5XoaJXl1u/u+jbXvvhhCt9YvA/B6VM3aM/77HuRQ94neS5bcisijGnKFQ==",
-      "cpu": [
-        "riscv64"
-      ],
+      "cpu": ["riscv64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -2648,14 +2592,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.16.tgz",
       "integrity": "sha512-jRqBCre9gZGoCdCN/UWCCMwCMsOg65IpY9Pyj56mKCF5zXy9d60kkNRdDN6YXGjr3rzcC4DXnS/kQVCGcC4yPQ==",
-      "cpu": [
-        "s390x"
-      ],
+      "cpu": ["s390x"],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -2664,14 +2604,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.16.tgz",
       "integrity": "sha512-G1+09TopOzo59/55lk5Q0UokghYLyHTKKzD5lXsAOOlGDbieGEFJpJBr3BLDbf7cz89KX04sBeExAR/pL/26sA==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -2680,14 +2616,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.16.tgz",
       "integrity": "sha512-xwjGJB5wwDEujLaJIrSMRqWkbigALpBNcsF9SqszoNKc+wY4kPTdKrSxiY5ik3IatojePP+WV108MvF6q6np4w==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "netbsd"
-      ],
+      "os": ["netbsd"],
       "engines": {
         "node": ">=12"
       }
@@ -2696,14 +2628,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.16.tgz",
       "integrity": "sha512-yeERkoxG2nR2oxO5n+Ms7MsCeNk23zrby2GXCqnfCpPp7KNc0vxaaacIxb21wPMfXXRhGBrNP4YLIupUBrWdlg==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "openbsd"
-      ],
+      "os": ["openbsd"],
       "engines": {
         "node": ">=12"
       }
@@ -2712,14 +2640,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.16.tgz",
       "integrity": "sha512-nHfbEym0IObXPhtX6Va3H5GaKBty2kdhlAhKmyCj9u255ktAj0b1YACUs9j5H88NRn9cJCthD1Ik/k9wn8YKVg==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "sunos"
-      ],
+      "os": ["sunos"],
       "engines": {
         "node": ">=12"
       }
@@ -2728,14 +2652,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.16.tgz",
       "integrity": "sha512-pdD+M1ZOFy4hE15ZyPX09fd5g4DqbbL1wXGY90YmleVS6Y5YlraW4BvHjim/X/4yuCpTsAFvsT4Nca2lbyDH/A==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "win32"
-      ],
+      "os": ["win32"],
       "engines": {
         "node": ">=12"
       }
@@ -2744,14 +2664,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.16.tgz",
       "integrity": "sha512-IPEMfU9p0c3Vb8PqxaPX6BM9rYwlTZGYOf9u+kMdhoILZkVKEjq6PKZO0lB+isojWwAnAqh4ZxshD96njTXajg==",
-      "cpu": [
-        "ia32"
-      ],
+      "cpu": ["ia32"],
       "dev": true,
       "optional": true,
-      "os": [
-        "win32"
-      ],
+      "os": ["win32"],
       "engines": {
         "node": ">=12"
       }
@@ -2760,14 +2676,10 @@
       "version": "0.16.16",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.16.tgz",
       "integrity": "sha512-1YYpoJ39WV/2bnShPwgdzJklc+XS0bysN6Tpnt1cWPdeoKOG4RMEY1g7i534QxXX/rPvNx/NLJQTTCeORYzipg==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "dev": true,
       "optional": true,
-      "os": [
-        "win32"
-      ],
+      "os": ["win32"],
       "engines": {
         "node": ">=12"
       }
@@ -16930,9 +16842,7 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
+      "engines": ["node >= 0.8"],
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -20473,9 +20383,7 @@
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -27368,9 +27276,7 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true,
-      "engines": [
-        "node >= 0.2.0"
-      ]
+      "engines": ["node >= 0.2.0"]
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
@@ -30792,9 +30698,7 @@
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
       "dev": true,
-      "engines": [
-        "node >= 0.2.0"
-      ],
+      "engines": ["node >= 0.2.0"],
       "inBundle": true,
       "license": "MIT"
     },

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -95,10 +95,9 @@
 
 # [1.0.0-alpha.11](https://github.com/cerebrl/forgerock-web-login-framework/compare/v1.0.0-alpha.10...v1.0.0-alpha.11) (2023-01-26)
 
-
 ### Features
 
-* **notify-slack:** slack notification on semantic-version-release ([d8552a0](https://github.com/cerebrl/forgerock-web-login-framework/commit/d8552a03a8cfdf3ce4f484e5de57c2a74ae26c5d))
+- **notify-slack:** slack notification on semantic-version-release ([d8552a0](https://github.com/cerebrl/forgerock-web-login-framework/commit/d8552a03a8cfdf3ce4f484e5de57c2a74ae26c5d))
 
 # [1.0.0-alpha.10](https://github.com/cerebrl/forgerock-web-login-framework/compare/v1.0.0-alpha.9...v1.0.0-alpha.10) (2023-01-25)
 

--- a/src/lib/components/compositions/dialog/dialog.story.svelte
+++ b/src/lib/components/compositions/dialog/dialog.story.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { z } from 'zod';
+
   /* eslint @typescript-eslint/no-empty-function: "off" */
   import Button from '$components/primitives/button/button.svelte';
   import Dialog from './dialog.svelte';
@@ -6,11 +8,11 @@
   import Input from '$components/compositions/input-floating/floating-label.svelte';
   import { initialize } from '$lib/style.store';
 
-  import type { Logo } from '$lib/style.store';
+  import type { logoSchema } from '$lib/style.store';
 
   // TODO: Export controls for changing dialog context
   export let forceOpen: boolean;
-  export let logo: Logo;
+  export let logo: z.infer<typeof logoSchema>;
   export let withHeader: boolean;
 
   let dialogEl: HTMLDialogElement;

--- a/src/lib/journey/_utilities/callback-mapper.svelte
+++ b/src/lib/journey/_utilities/callback-mapper.svelte
@@ -8,6 +8,7 @@
   */
 
   import { CallbackType } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   // Callback handler components
   import Boolean from '$journey/callbacks/boolean/boolean.svelte';
@@ -51,7 +52,7 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   export let props: {
@@ -59,7 +60,7 @@
     callbackMetadata: Maybe<CallbackMetadata>;
     selfSubmitFunction: SelfSubmitFunction;
     stepMetadata: Maybe<StepMetadata>;
-    style: Style;
+    style: z.infer<typeof styleSchema>;
   };
 
   let cbType: string;

--- a/src/lib/journey/callbacks/boolean/boolean.svelte
+++ b/src/lib/journey/callbacks/boolean/boolean.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getAttributeValidationFailureText } from '$journey/callbacks/_utilities/callback.utilities';
   import type { AttributeInputCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import Animated from '$components/compositions/checkbox/animated.svelte';
   import { interpolate, textToKey } from '$lib/_utilities/i18n.utilities';
@@ -11,14 +12,14 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   export let callback: AttributeInputCallback<boolean>;
   export let callbackMetadata: Maybe<CallbackMetadata>;
   export const stepMetadata: Maybe<StepMetadata> = null;
   export const selfSubmitFunction: Maybe<SelfSubmitFunction> = null;
-  export let style: Style = {};
+  export let style: z.infer<typeof styleSchema> = {};
 
   const Checkbox = style.checksAndRadios === 'standard' ? Standard : Animated;
 

--- a/src/lib/journey/callbacks/choice/choice.svelte
+++ b/src/lib/journey/callbacks/choice/choice.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ChoiceCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import Radio from '$components/compositions/radio/animated.svelte';
   import Select from '$components/compositions/select-floating/floating-label.svelte';
@@ -10,13 +11,13 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   // Unused props. Setting to const prevents errors in console
   export const selfSubmitFunction: Maybe<SelfSubmitFunction> = null;
   export const stepMetadata: Maybe<StepMetadata> = null;
-  export const style: Style = {};
+  export const style: z.infer<typeof styleSchema> = {};
 
   export let callback: ChoiceCallback;
   export let callbackMetadata: Maybe<CallbackMetadata>;

--- a/src/lib/journey/callbacks/confirmation/confirmation.svelte
+++ b/src/lib/journey/callbacks/confirmation/confirmation.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ConfirmationCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import Animated from '$components/compositions/checkbox/animated.svelte';
   import Standard from '$components/compositions/checkbox/standard.svelte';
@@ -13,11 +14,11 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   // Unused props. Setting to const prevents errors in console
-  export const style: Style = {};
+  export const style: z.infer<typeof styleSchema> = {};
 
   export let callback: ConfirmationCallback;
   export let callbackMetadata: Maybe<CallbackMetadata>;

--- a/src/lib/journey/callbacks/hidden-value/hidden-value.svelte
+++ b/src/lib/journey/callbacks/hidden-value/hidden-value.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
+  import type { z } from 'zod';
+
   import type {
     CallbackMetadata,
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
   import type { HiddenValueCallback } from '@forgerock/javascript-sdk';
 
   export const callbackMetadata: Maybe<CallbackMetadata> = null;
   export const selfSubmitFunction: Maybe<SelfSubmitFunction> = null;
   export const stepMetadata: Maybe<StepMetadata> = null;
-  export const style: Style = {};
+  export const style: z.infer<typeof styleSchema> = {};
 
   export const callback: Maybe<HiddenValueCallback> = null;
 </script>

--- a/src/lib/journey/callbacks/kba/kba-create.svelte
+++ b/src/lib/journey/callbacks/kba/kba-create.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { KbaCreateCallback, NameValue } from '@forgerock/javascript-sdk';
   import { writable } from 'svelte/store';
+  import type { z } from 'zod';
 
   import Floating from '$components/compositions/input-floating/floating-label.svelte';
   import Stacked from '$components/compositions/input-stacked/stacked-label.svelte';
@@ -14,7 +15,7 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   // Unused props. Setting to const prevents errors in console
@@ -23,7 +24,7 @@
 
   export let callback: KbaCreateCallback;
   export let callbackMetadata: Maybe<CallbackMetadata>;
-  export let style: Style = {};
+  export let style: z.infer<typeof styleSchema> = {};
 
   const Input = style.labels === 'stacked' ? Stacked : Floating;
 

--- a/src/lib/journey/callbacks/password/base.svelte
+++ b/src/lib/journey/callbacks/password/base.svelte
@@ -3,6 +3,7 @@
     PasswordCallback,
     ValidatedCreatePasswordCallback,
   } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import ConfirmInput from './confirm-input.svelte';
   import EyeIcon from '$components/icons/eye-icon.svelte';
@@ -13,14 +14,14 @@
 
   import type { Maybe } from '$lib/interfaces';
   import type { CallbackMetadata } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
 
   export let callback: PasswordCallback | ValidatedCreatePasswordCallback;
   export let callbackMetadata: Maybe<CallbackMetadata>;
   export let key: string;
   export let isInvalid = false;
   export let isRequired = false;
-  export let style: Style = {};
+  export let style: z.infer<typeof styleSchema> = {};
 
   const Input = style.labels === 'stacked' ? Stacked : Floating;
 

--- a/src/lib/journey/callbacks/password/confirm-input.svelte
+++ b/src/lib/journey/callbacks/password/confirm-input.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { z } from 'zod';
+
   import EyeIcon from '$components/icons/eye-icon.svelte';
   import Floating from '$components/compositions/input-floating/floating-label.svelte';
   import { interpolate } from '$lib/_utilities/i18n.utilities';
@@ -6,14 +8,14 @@
   import T from '$components/_utilities/locale-strings.svelte';
 
   import type { Maybe } from '$lib/interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
 
   export let forceValidityFailure = false;
   export let key: string;
   export let onChange: (event: Event) => void;
   export let isInvalid = false;
   export let isRequired = true;
-  export let style: Style = {};
+  export let style: z.infer<typeof styleSchema> = {};
 
   const Input = style.labels === 'stacked' ? Stacked : Floating;
 

--- a/src/lib/journey/callbacks/password/password.svelte
+++ b/src/lib/journey/callbacks/password/password.svelte
@@ -6,6 +6,8 @@
    * allow for easier typing for the callback.
    */
   import type { PasswordCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
+
 
   import Base from './base.svelte';
 
@@ -14,7 +16,7 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   // Unused props. Setting to const prevents errors in console
@@ -23,7 +25,7 @@
 
   export let callback: PasswordCallback;
   export let callbackMetadata: Maybe<CallbackMetadata>;
-  export let style: Style = {};
+  export let style: z.infer<typeof styleSchema> = {};
 
 
   let inputName: string;

--- a/src/lib/journey/callbacks/password/validated-create-password.svelte
+++ b/src/lib/journey/callbacks/password/validated-create-password.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ValidatedCreatePasswordCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import { getValidationFailures } from '$journey/callbacks/_utilities/callback.utilities';
   import Base from '$journey/callbacks/password/base.svelte';
@@ -14,7 +15,7 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   // Unused props. Setting to const prevents errors in console
@@ -23,7 +24,7 @@
 
   export let callback: ValidatedCreatePasswordCallback;
   export let callbackMetadata: Maybe<CallbackMetadata>;
-  export let style: Style = {};
+  export let style: z.infer<typeof styleSchema> = {};
 
   const isRequired = isInputRequired(callback);
 

--- a/src/lib/journey/callbacks/polling-wait/polling-wait.svelte
+++ b/src/lib/journey/callbacks/polling-wait/polling-wait.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { PollingWaitCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import Spinner from '$components/primitives/spinner/spinner.svelte';
   import Text from '$components/primitives/text/text.svelte';
@@ -9,12 +10,12 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   // Unused props. Setting to const prevents errors in console
   export const stepMetadata: Maybe<StepMetadata> = null;
-  export const style: Style = {};
+  export const style: z.infer<typeof styleSchema> = {};
 
   export let callback: PollingWaitCallback;
   export let callbackMetadata: Maybe<CallbackMetadata>;

--- a/src/lib/journey/callbacks/redirect/redirect.svelte
+++ b/src/lib/journey/callbacks/redirect/redirect.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { RedirectCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import type {
     CallbackMetadata,
@@ -9,14 +10,14 @@
   import { interpolate } from '$lib/_utilities/i18n.utilities';
   import Spinner from '$components/primitives/spinner/spinner.svelte';
   import Text from '$components/primitives/text/text.svelte';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   // Unused props. Setting to const prevents errors in console
   export const callbackMetadata: Maybe<CallbackMetadata> = null;
   export const selfSubmitFunction: Maybe<SelfSubmitFunction> = null;
   export const stepMetadata: Maybe<StepMetadata> = null;
-  export const style: Style = {};
+  export const style: z.infer<typeof styleSchema> = {};
 
   export let callback: RedirectCallback;
 

--- a/src/lib/journey/callbacks/select-idp/select-idp.svelte
+++ b/src/lib/journey/callbacks/select-idp/select-idp.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { SelectIdPCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
+
   import AppleIcon from '../../../components/icons/apple-icon.svelte';
   import FacebookIcon from '../../../components/icons/facebook-icon.svelte';
   import GoogleIcon from '../../../components/icons/google-icon.svelte';
@@ -12,10 +14,10 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
-  export const style: Style = {};
+  export const style: z.infer<typeof styleSchema> = {};
 
   export let callback: SelectIdPCallback;
   export let callbackMetadata: Maybe<CallbackMetadata>;

--- a/src/lib/journey/callbacks/string-attribute/string-attribute-input.svelte
+++ b/src/lib/journey/callbacks/string-attribute/string-attribute-input.svelte
@@ -5,6 +5,7 @@
     type FailedPolicy,
   } from '$journey/callbacks/_utilities/callback.utilities';
   import type { AttributeInputCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import {
     getValidationFailures,
@@ -18,14 +19,14 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
   import type { StringDict } from '@forgerock/javascript-sdk/lib/shared/interfaces';
 
   // Unused props. Setting to const prevents errors in console
   export const selfSubmitFunction: Maybe<SelfSubmitFunction> = null;
   export const stepMetadata: Maybe<StepMetadata> = null;
-  export const style: Style = {};
+  export const style: z.infer<typeof styleSchema> = {};
 
   export let callback: AttributeInputCallback<string>;
   export let callbackMetadata: Maybe<CallbackMetadata>;

--- a/src/lib/journey/callbacks/terms-and-conditions/terms-conditions.svelte
+++ b/src/lib/journey/callbacks/terms-and-conditions/terms-conditions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { TermsAndConditionsCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import Animated from '$components/compositions/checkbox/animated.svelte';
   import { interpolate } from '$lib/_utilities/i18n.utilities';
@@ -13,14 +14,14 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
   import { derived } from 'svelte/store';
 
   // Unused props. Setting to const` prevents errors in console
   export const selfSubmitFunction: Maybe<SelfSubmitFunction> = null;
   export const stepMetadata: Maybe<StepMetadata> = null;
-  export const style: Style = {};
+  export const style: z.infer<typeof styleSchema> = {};
 
   export let callback: TermsAndConditionsCallback;
   export let checkAndRadioType: 'animated' | 'standard' = 'animated';

--- a/src/lib/journey/callbacks/text-output/text-output.svelte
+++ b/src/lib/journey/callbacks/text-output/text-output.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { SuspendedTextOutputCallback, TextOutputCallback } from '@forgerock/javascript-sdk';
   import sanitize from 'xss';
+  import type { z } from 'zod';
 
   import Text from '$components/primitives/text/text.svelte';
 
@@ -9,14 +10,14 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   // Unused props. Setting to const prevents errors in console
   export const callbackMetadata: Maybe<CallbackMetadata> = null;
   export const selfSubmitFunction: Maybe<SelfSubmitFunction> = null;
   export const stepMetadata: Maybe<StepMetadata> = null;
-  export const style: Style = {};
+  export const style: z.infer<typeof styleSchema> = {};
 
   export let callback: SuspendedTextOutputCallback | TextOutputCallback;
 

--- a/src/lib/journey/callbacks/unknown/unknown.svelte
+++ b/src/lib/journey/callbacks/unknown/unknown.svelte
@@ -1,18 +1,20 @@
 <script lang="ts">
+  import type { z } from 'zod';
+
   import type {
     CallbackMetadata,
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
   import type { Maybe } from '$lib/interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { FRCallback } from '@forgerock/javascript-sdk';
 
   // Unused props. Setting to const prevents errors in console
   export const callbackMetadata: Maybe<CallbackMetadata> = null;
   export const selfSubmitFunction: Maybe<SelfSubmitFunction> = null;
   export const stepMetadata: Maybe<StepMetadata> = null;
-  export const style: Style = {};
+  export const style: z.infer<typeof styleSchema> = {};
 
   export let callback: FRCallback;
 

--- a/src/lib/journey/callbacks/username/name.svelte
+++ b/src/lib/journey/callbacks/username/name.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { NameCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import Floating from '$components/compositions/input-floating/floating-label.svelte';
   import { interpolate, textToKey } from '$lib/_utilities/i18n.utilities';
@@ -10,7 +11,7 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   // Unused props. Setting to const prevents errors in console
@@ -19,7 +20,7 @@
 
   export let callback: NameCallback;
   export let callbackMetadata: Maybe<CallbackMetadata>;
-  export let style: Style = {};
+  export let style: z.infer<typeof styleSchema> = {};
 
   const Input = style.labels === 'stacked' ? Stacked : Floating;
 

--- a/src/lib/journey/callbacks/username/validated-create-username.svelte
+++ b/src/lib/journey/callbacks/username/validated-create-username.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ValidatedCreateUsernameCallback } from '@forgerock/javascript-sdk';
+  import type { z } from 'zod';
 
   import {
     getValidationFailures,
@@ -16,7 +17,7 @@
     SelfSubmitFunction,
     StepMetadata,
   } from '$journey/journey.interfaces';
-  import type { Style } from '$lib/style.store';
+  import type { styleSchema } from '$lib/style.store';
   import type { Maybe } from '$lib/interfaces';
 
   // Unused props. Setting to const prevents errors in console
@@ -25,7 +26,7 @@
 
   export let callback: ValidatedCreateUsernameCallback;
   export let callbackMetadata: Maybe<CallbackMetadata>;
-  export let style: Style = {};
+  export let style: z.infer<typeof styleSchema> = {};
 
   const Input = style.labels === 'stacked' ? Stacked : Floating;
 

--- a/src/lib/links.store.ts
+++ b/src/lib/links.store.ts
@@ -8,11 +8,15 @@ export const linksSchema = z
   .strict();
 
 export const partialLinksSchema = linksSchema.partial();
-export let links: Readable<Record<string, string> | null>;
+export let links: Readable<z.infer<typeof partialLinksSchema> | undefined>;
 
 export function initialize(customLinks?: z.infer<typeof partialLinksSchema>) {
-  // Provide developer feedback for custom links
-  linksSchema.parse(customLinks);
-
-  links = readable(customLinks);
+  // If customLinks is provided, provide feedback for object
+  if (customLinks) {
+    // Provide developer feedback for custom links
+    linksSchema.parse(customLinks);
+    links = readable(customLinks);
+  } else {
+    links = readable();
+  }
 }

--- a/src/lib/sdk.config.ts
+++ b/src/lib/sdk.config.ts
@@ -83,19 +83,7 @@ const configSchema = z
   .strict();
 export const partialConfigSchema = configSchema.partial();
 
-// const defaultPaths = {
-//   authenticate: 'authenticate',
-//   authorize: 'authorize',
-//   accessToken: 'tokens',
-//   endSession: 'end-session',
-//   userInfo: 'userinfo',
-//   revoke: 'revoke',
-//   sessions: 'sessions',
-// };
-
-export default function (config?: z.infer<typeof partialConfigSchema>) {
-  if (config) {
-    configSchema.parse(config);
-    Config.set(config);
-  }
+export default function (config: z.infer<typeof partialConfigSchema>) {
+  configSchema.parse(config);
+  Config.set(config);
 }

--- a/src/lib/sdk.config.ts
+++ b/src/lib/sdk.config.ts
@@ -93,7 +93,9 @@ export const partialConfigSchema = configSchema.partial();
 //   sessions: 'sessions',
 // };
 
-export default function (config: z.infer<typeof partialConfigSchema>) {
-  configSchema.parse(config);
-  Config.set(config);
+export default function (config?: z.infer<typeof partialConfigSchema>) {
+  if (config) {
+    configSchema.parse(config);
+    Config.set(config);
+  }
 }

--- a/src/lib/widget/_utilities/api.utilities.ts
+++ b/src/lib/widget/_utilities/api.utilities.ts
@@ -1,0 +1,215 @@
+import type { z } from 'zod';
+
+// Import the stores for initialization
+import configure from '$lib/sdk.config';
+
+// Import store types
+import type { JourneyOptions, Modal, Response, WidgetApiParams } from '../interfaces';
+import type { JourneyStore, JourneyStoreValue } from '$journey/journey.interfaces';
+import type { OAuthStore, OAuthTokenStoreValue } from '$lib/oauth/oauth.store';
+import type { partialConfigSchema } from '$lib/sdk.config';
+import type { UserStore } from '$lib/user/user.store';
+import type { HttpClientRequestOptions } from '@forgerock/javascript-sdk/lib/http-client';
+import HttpClient from '@forgerock/javascript-sdk/lib/http-client';
+import {
+  Config,
+  FRUser,
+  SessionManager,
+  TokenManager,
+  UserManager,
+  type GetTokensOptions,
+} from '@forgerock/javascript-sdk';
+import { get } from 'svelte/store';
+
+export function widgetApiFactory(widgetApiParams: WidgetApiParams) {
+  const configuration = {
+    set(options: z.infer<typeof partialConfigSchema>): void {
+      // Set base config to SDK
+      // TODO: Move to a shared utility
+      configure({
+        // Set some basics by default
+        ...{
+          // TODO: Could this be a default OAuth client provided by Platform UI OOTB?
+          clientId: 'WebLoginWidgetClient',
+          // TODO: If a realmPath is not provided, should we call the realm endpoint and detect a likely default?
+          // https://backstage.forgerock.com/docs/am/7/setup-guide/sec-rest-realm-rest.html#rest-api-list-realm
+          realmPath: 'alpha',
+          // TODO: Once we move to SSR, this default should be more intelligent
+          redirectUri:
+            typeof window === 'object' ? window.location.href : 'https://localhost:3000/callback',
+          scope: 'openid email',
+        },
+        // Let user provided config override defaults
+        ...options,
+        // Force 'legacy' to remove confusion
+        ...{ support: 'legacy' },
+      });
+    },
+  };
+  const journey = {
+    start(options?: JourneyOptions): void {
+      const requestsOauth = options?.oauth || true;
+      const requestsUser = options?.user || true;
+
+      const journeyStore = widgetApiParams.journeyStore as JourneyStore;
+      const modal = widgetApiParams.modal as Modal;
+      const oauthStore = widgetApiParams.oauthStore as OAuthStore;
+      const returnError = widgetApiParams.returnError as (response: Response) => void;
+      const returnResponse = widgetApiParams.returnResponse as (response: Response) => void;
+      const userStore = widgetApiParams.userStore as UserStore;
+
+      let journey: JourneyStoreValue;
+      let oauth: OAuthTokenStoreValue;
+
+      const journeyStoreUnsub = journeyStore.subscribe((response) => {
+        if (!requestsOauth && response.successful) {
+          returnResponse &&
+            returnResponse({
+              journey: response,
+            });
+          modal.close({ reason: 'auto' });
+        } else if (requestsOauth && response.successful) {
+          journey = response;
+          oauthStore.get({ forceRenew: true });
+        } else if (response.error) {
+          journey = response;
+          returnError &&
+            returnError({
+              journey: response,
+            });
+        }
+        /**
+         * Clean up unneeded subscription, but only when it's successful
+         * Leaving the subscription allows for the journey to be
+         * restarted internally.
+         */
+        if (response.successful) {
+          journeyStoreUnsub();
+        }
+      });
+
+      const oauthStoreUnsub = oauthStore.subscribe((response) => {
+        if (!requestsUser && response.successful) {
+          returnResponse &&
+            returnResponse({
+              journey,
+              oauth: response,
+            });
+          modal.close({ reason: 'auto' });
+        } else if (requestsUser && response.successful) {
+          oauth = response;
+          userStore.get();
+        } else if (response.error) {
+          oauth = response;
+          returnError &&
+            returnError({
+              journey,
+              oauth: response,
+            });
+        }
+        /**
+         * Clean up unneeded subscription, but only when it's successful
+         * Leaving the subscription allows for the journey to be
+         * restarted internally.
+         */
+        if (response.successful) {
+          oauthStoreUnsub();
+        }
+      });
+      const userStoreUnsub = userStore.subscribe((response) => {
+        if (response.successful) {
+          returnResponse &&
+            returnResponse({
+              journey,
+              oauth,
+              user: response,
+            });
+          modal.close({ reason: 'auto' });
+        } else if (response.error) {
+          returnError &&
+            returnError({
+              journey,
+              oauth,
+              user: response,
+            });
+        }
+        /**
+         * Clean up unneeded subscription, but only when it's successful
+         * Leaving the subscription allows for the journey to be
+         * restarted internally.
+         */
+        if (response.successful) {
+          userStoreUnsub();
+        }
+      });
+
+      if (options?.resumeUrl) {
+        journeyStore.resume(options.resumeUrl);
+      } else {
+        journeyStore.start({
+          ...options?.config,
+          tree: options?.journey,
+        });
+      }
+    },
+    onFailure(fn: (response: Response) => void) {
+      widgetApiParams.returnError = (response) => fn(response);
+    },
+    onSuccess(fn: (response: Response) => void) {
+      widgetApiParams.returnResponse = (response) => fn(response);
+    },
+  };
+  const user = {
+    async authorized(remote = false) {
+      if (remote) {
+        return !!(await UserManager.getCurrentUser());
+      }
+      return !!(await TokenManager.getTokens());
+    },
+    async info(remote = false) {
+      widgetApiParams.userStore = widgetApiParams.userStore as UserStore;
+      if (remote) {
+        return await UserManager.getCurrentUser();
+      }
+      return get(widgetApiParams.userStore).response;
+    },
+    logout: async () => {
+      const { clientId } = Config.get();
+
+      widgetApiParams.journeyStore = widgetApiParams.journeyStore as JourneyStore;
+      widgetApiParams.oauthStore = widgetApiParams.oauthStore as OAuthStore;
+      widgetApiParams.userStore = widgetApiParams.userStore as UserStore;
+
+      /**
+       * If configuration has a clientId, then use FRUser to logout to ensure
+       * token revoking and removal; else, just end the session.
+       */
+      if (clientId) {
+        // Call SDK logout
+        await FRUser.logout();
+      } else {
+        await SessionManager.logout();
+      }
+
+      // Reset stores
+      widgetApiParams.journeyStore.reset();
+      widgetApiParams.oauthStore.reset();
+      widgetApiParams.userStore.reset();
+
+      // Fetch fresh journey step
+      journey.start();
+    },
+    async tokens(options?: GetTokensOptions) {
+      return await TokenManager.getTokens(options);
+    },
+  };
+
+  return {
+    configuration,
+    journey,
+    async request(options: HttpClientRequestOptions) {
+      return await HttpClient.request(options);
+    },
+    user,
+  };
+}

--- a/src/lib/widget/_utilities/api.utilities.ts
+++ b/src/lib/widget/_utilities/api.utilities.ts
@@ -172,7 +172,8 @@ export function widgetApiFactory(modal?: Modal) {
         try {
           return await UserManager.getCurrentUser();
         } catch (err) {
-          return null;
+          console.warn(err);
+          return;
         }
       }
       return !!(await TokenManager.getTokens());
@@ -183,7 +184,8 @@ export function widgetApiFactory(modal?: Modal) {
         try {
           return await UserManager.getCurrentUser();
         } catch (err) {
-          return null;
+          console.warn(err);
+          return;
         }
       }
       return get(userStore).response;
@@ -217,6 +219,7 @@ export function widgetApiFactory(modal?: Modal) {
       try {
         return await TokenManager.getTokens(options);
       } catch (err) {
+        console.warn(err);
         return;
       }
     },

--- a/src/lib/widget/inline.svelte
+++ b/src/lib/widget/inline.svelte
@@ -177,7 +177,6 @@
 
   import type { partialConfigSchema } from '$lib/sdk.config';
   import type { journeyConfigSchema } from '$journey/config.store';
-  import type { Maybe } from '$lib/interfaces';
   import type { partialStringsSchema } from '$lib/locale.store';
 
   export let config: z.infer<typeof partialConfigSchema>;

--- a/src/lib/widget/inline.svelte
+++ b/src/lib/widget/inline.svelte
@@ -1,166 +1,25 @@
 <script context="module" lang="ts">
-  import {
-    Config,
-    FRUser,
-    type GetTokensOptions,
-    SessionManager,
-    TokenManager,
-    UserManager,
-  } from '@forgerock/javascript-sdk';
-  import { get } from 'svelte/store';
-
-  // Import store types
-  import type { JourneyOptions, Response } from './interfaces';
-  import type { JourneyStore, JourneyStoreValue } from '$journey/journey.interfaces';
-  import type { OAuthStore, OAuthTokenStoreValue } from '$lib/oauth/oauth.store';
-  import type { UserStore } from '$lib/user/user.store';
+  import { widgetApiFactory } from './_utilities/api.utilities';
 
   import './main.css';
 
   let callMounted: (form: HTMLFormElement) => void;
-  let journeyStore: JourneyStore;
-  let oauthStore: OAuthStore;
-  let returnError: (response: Response) => void;
-  let returnResponse: (response: Response) => void;
-  let userStore: UserStore;
 
-  export const journey = {
-    start(options?: JourneyOptions): void {
-      const requestsOauth = options?.oauth || true;
-      const requestsUser = options?.user || true;
+  const api = widgetApiFactory();
 
-      let journey: JourneyStoreValue;
-      let oauth: OAuthTokenStoreValue;
-      let journeyStoreUnsub = journeyStore.subscribe((response) => {
-        if (!requestsOauth && response.successful) {
-          returnResponse &&
-            returnResponse({
-              journey: response,
-            });
-        } else if (requestsOauth && response.successful) {
-          journey = response;
-          oauthStore.get({ forceRenew: true });
-        } else if (response.error) {
-          journey = response;
-          returnError &&
-            returnError({
-              journey: response,
-            });
-        }
-        // Clean up unneeded subscription
-        if (response.completed) {
-          journeyStoreUnsub();
-        }
-      });
-      let oauthStoreUnsub = oauthStore.subscribe((response) => {
-        if (!requestsUser && response.successful) {
-          returnResponse &&
-            returnResponse({
-              journey,
-              oauth: response,
-            });
-        } else if (requestsUser && response.successful) {
-          oauth = response;
-          userStore.get();
-        } else if (response.error) {
-          oauth = response;
-          returnError &&
-            returnError({
-              journey,
-              oauth: response,
-            });
-        }
-        // Clean up unneeded subscription
-        if (response.completed) {
-          oauthStoreUnsub();
-        }
-      });
-      let userStoreUnsub = userStore.subscribe((response) => {
-        if (response.successful) {
-          returnResponse &&
-            returnResponse({
-              journey,
-              oauth,
-              user: response,
-            });
-        } else if (response.error) {
-          returnError &&
-            returnError({
-              journey,
-              oauth,
-              user: response,
-            });
-        }
-        // Clean up unneeded subscription
-        if (response.completed) {
-          userStoreUnsub();
-        }
-      });
-
-      if (options?.resumeUrl) {
-        journeyStore.resume(options.resumeUrl);
-      } else {
-        journeyStore.start({
-          ...options?.config,
-          tree: options?.journey,
-        });
-      }
-    },
-    onFailure(fn: (response: Response) => void) {
-      returnError = (response: Response) => fn(response);
-    },
-    onSuccess(fn: (response: Response) => void) {
-      returnResponse = (response: Response) => fn(response);
-    },
-  };
+  export const configuration = api.configuration;
   export const form = {
     onMount(fn: (form: HTMLFormElement) => void) {
       callMounted = (form: HTMLFormElement) => fn(form);
     },
   };
-  export const user = {
-    async authorized(remote = false) {
-      if (remote) {
-        return !!(await UserManager.getCurrentUser());
-      }
-      return !!(await TokenManager.getTokens());
-    },
-    async info(remote = false) {
-      if (remote) {
-        return await UserManager.getCurrentUser();
-      }
-      return get(userStore).response;
-    },
-    async logout() {
-      const { clientId } = Config.get();
-
-      /**
-       * If configuration has a clientId, then use FRUser to logout to ensure
-       * token revoking and removal; else, just end the session.
-       */
-      if (clientId) {
-        // Call SDK logout
-        await FRUser.logout();
-      } else {
-        await SessionManager.logout();
-      }
-
-      // Reset stores
-      journeyStore.reset();
-      oauthStore.reset();
-      userStore.reset();
-
-      // Fetch fresh journey step
-      journey.start();
-    },
-    async tokens(options?: GetTokensOptions) {
-      return await TokenManager.getTokens(options);
-    },
-  };
+  export const journey = api.journey;
+  export const request = api.request;
+  export const user = api.user;
 </script>
 
 <script lang="ts">
-  import { createEventDispatcher, onMount as s_onMount } from 'svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
   import type { z } from 'zod';
 
   import Journey from '$journey/journey.svelte';
@@ -179,7 +38,7 @@
   import type { journeyConfigSchema } from '$journey/config.store';
   import type { partialStringsSchema } from '$lib/locale.store';
 
-  export let config: z.infer<typeof partialConfigSchema>;
+  export let config: z.infer<typeof partialConfigSchema> | undefined = undefined;
   export let content: z.infer<typeof partialStringsSchema>;
   export let journeys: z.infer<typeof journeyConfigSchema> | undefined = undefined;
   export let links: z.infer<typeof partialLinksSchema> | undefined = undefined;
@@ -190,41 +49,43 @@
   // A reference to the `form` DOM element
   let formEl: HTMLFormElement;
 
-  // Set base config to SDK
-  // TODO: Move to a shared utility
-  configure({
-    // Set some basics by default
-    ...{
-      // TODO: Could this be a default OAuth client provided by Platform UI OOTB?
-      clientId: 'WebLoginWidgetClient',
-      // TODO: If a realmPath is not provided, should we call the realm endpoint and detect a likely default?
-      // https://backstage.forgerock.com/docs/am/7/setup-guide/sec-rest-realm-rest.html#rest-api-list-realm
-      realmPath: 'alpha',
-      // TODO: Once we move to SSR, this default should be more intelligent
-      redirectUri:
-        typeof window === 'object' ? window.location.href : 'https://localhost:3000/callback',
-      scope: 'openid email',
-    },
-    // Let user provided config override defaults
-    ...config,
-    // Force 'legacy' to remove confusion
-    ...{ support: 'legacy' },
-  });
+  if (config) {
+    // Set base config to SDK
+    // TODO: Move to a shared utility
+    configure({
+      // Set some basics by default
+      ...{
+        // TODO: Could this be a default OAuth client provided by Platform UI OOTB?
+        clientId: 'WebLoginWidgetClient',
+        // TODO: If a realmPath is not provided, should we call the realm endpoint and detect a likely default?
+        // https://backstage.forgerock.com/docs/am/7/setup-guide/sec-rest-realm-rest.html#rest-api-list-realm
+        realmPath: 'alpha',
+        // TODO: Once we move to SSR, this default should be more intelligent
+        redirectUri:
+          typeof window === 'object' ? window.location.href : 'https://localhost:3000/callback',
+        scope: 'openid email',
+      },
+      // Let user provided config override defaults
+      ...config,
+      // Force 'legacy' to remove confusion
+      ...{ support: 'legacy' },
+    });
+  }
 
   /**
    * Initialize the stores and ensure both variables point to the same reference.
    * Variables with _ are the reactive version of the original variable from above.
    */
-  let _journeyStore = (journeyStore = initializeJourney(config));
-  let _oauthStore = (oauthStore = initializeOauth(config));
-  let _userStore = (userStore = initializeUser(config));
+  api.setJourneyStore(initializeJourney(config));
+  api.setOAuthStore(initializeOauth(config));
+  api.setUserStore(initializeUser(config));
 
   initializeContent(content);
   initializeJourneys(journeys);
   initializeLinks(links);
   initializeStyle(style);
 
-  s_onMount(() => {
+  onMount(() => {
     /**
      * Call mounted event for Singleton users
      */
@@ -242,5 +103,9 @@
 
 <div class="fr_widget-root">
   <!-- Default `displayIcon` to `true` if `style.stages.icon` is `undefined` or `null` -->
-  <Journey bind:formEl displayIcon={style?.stage?.icon ?? true} journeyStore={_journeyStore} />
+  <Journey
+    bind:formEl
+    displayIcon={style?.stage?.icon ?? true}
+    journeyStore={api.getJourneyStore()}
+  />
 </div>

--- a/src/lib/widget/inline.svelte
+++ b/src/lib/widget/inline.svelte
@@ -32,17 +32,18 @@
   import { initialize as initializeLinks, partialLinksSchema } from '$lib/links.store';
   import { initialize as initializeOauth } from '$lib/oauth/oauth.store';
   import { initialize as initializeUser } from '$lib/user/user.store';
-  import { initialize as initializeStyle, type Style } from '$lib/style.store';
+  import { initialize as initializeStyle } from '$lib/style.store';
 
   import type { partialConfigSchema } from '$lib/sdk.config';
   import type { journeyConfigSchema } from '$journey/config.store';
   import type { partialStringsSchema } from '$lib/locale.store';
+  import type { partialStyleSchema } from '$lib/style.store';
 
   export let config: z.infer<typeof partialConfigSchema> | undefined = undefined;
-  export let content: z.infer<typeof partialStringsSchema>;
+  export let content: z.infer<typeof partialStringsSchema> | undefined = undefined;
   export let journeys: z.infer<typeof journeyConfigSchema> | undefined = undefined;
   export let links: z.infer<typeof partialLinksSchema> | undefined = undefined;
-  export let style: Style | undefined = undefined;
+  export let style: z.infer<typeof partialStyleSchema> | undefined = undefined;
 
   const dispatch = createEventDispatcher();
 

--- a/src/lib/widget/interfaces.ts
+++ b/src/lib/widget/interfaces.ts
@@ -1,10 +1,9 @@
 import type { StepOptions } from '@forgerock/javascript-sdk/lib/auth/interfaces';
 
 // Import store types
-import type { JourneyStore, JourneyStoreValue } from '$journey/journey.interfaces';
-import type { Maybe } from '$lib/interfaces';
-import type { OAuthStore, OAuthTokenStoreValue } from '$lib/oauth/oauth.store';
-import type { UserStore, UserStoreValue } from '$lib/user/user.store';
+import type { JourneyStoreValue } from '$journey/journey.interfaces';
+import type { OAuthTokenStoreValue } from '$lib/oauth/oauth.store';
+import type { UserStoreValue } from '$lib/user/user.store';
 
 export interface JourneyOptions {
   config?: StepOptions;
@@ -18,14 +17,6 @@ export interface Modal {
   onClose(fn: (args: { reason: 'auto' | 'external' | 'user' }) => void): void;
   onMount(fn: (dialog: HTMLDialogElement, form: HTMLFormElement) => void): void;
   open(options?: JourneyOptions): void;
-}
-export interface WidgetApiParams {
-  journeyStore: Maybe<JourneyStore>;
-  modal: Modal;
-  oauthStore: Maybe<OAuthStore>;
-  returnError: Maybe<(response: Response) => void>;
-  returnResponse: Maybe<(response: Response) => void>;
-  userStore: Maybe<UserStore>;
 }
 export interface Response {
   journey?: JourneyStoreValue;

--- a/src/lib/widget/interfaces.ts
+++ b/src/lib/widget/interfaces.ts
@@ -1,19 +1,34 @@
 import type { StepOptions } from '@forgerock/javascript-sdk/lib/auth/interfaces';
 
 // Import store types
-import type { JourneyStoreValue } from '$journey/journey.interfaces';
-import type { OAuthTokenStoreValue } from '$lib/oauth/oauth.store';
-import type { UserStoreValue } from '$lib/user/user.store';
+import type { JourneyStore, JourneyStoreValue } from '$journey/journey.interfaces';
+import type { Maybe } from '$lib/interfaces';
+import type { OAuthStore, OAuthTokenStoreValue } from '$lib/oauth/oauth.store';
+import type { UserStore, UserStoreValue } from '$lib/user/user.store';
 
-export interface Response {
-  journey?: JourneyStoreValue;
-  oauth?: OAuthTokenStoreValue;
-  user?: UserStoreValue;
-}
 export interface JourneyOptions {
   config?: StepOptions;
   journey?: string;
   oauth?: boolean; // defaults to true
   resumeUrl?: string; // current URL if resuming a journey/tree
   user?: boolean; // defaults to true
+}
+export interface Modal {
+  close(args?: { reason: 'auto' | 'external' | 'user' }): void;
+  onClose(fn: (args: { reason: 'auto' | 'external' | 'user' }) => void): void;
+  onMount(fn: (dialog: HTMLDialogElement, form: HTMLFormElement) => void): void;
+  open(options?: JourneyOptions): void;
+}
+export interface WidgetApiParams {
+  journeyStore: Maybe<JourneyStore>;
+  modal: Modal;
+  oauthStore: Maybe<OAuthStore>;
+  returnError: Maybe<(response: Response) => void>;
+  returnResponse: Maybe<(response: Response) => void>;
+  userStore: Maybe<UserStore>;
+}
+export interface Response {
+  journey?: JourneyStoreValue;
+  oauth?: OAuthTokenStoreValue;
+  user?: UserStoreValue;
 }

--- a/src/lib/widget/modal.svelte
+++ b/src/lib/widget/modal.svelte
@@ -54,17 +54,18 @@
   import { initialize as initializeLinks, partialLinksSchema } from '$lib/links.store';
   import { initialize as initializeOauth } from '$lib/oauth/oauth.store';
   import { initialize as initializeUser } from '$lib/user/user.store';
-  import { initialize as initializeStyle, type Style } from '$lib/style.store';
+  import { initialize as initializeStyle } from '$lib/style.store';
 
   import type { partialConfigSchema } from '$lib/sdk.config';
   import type { journeyConfigSchema } from '$journey/config.store';
   import type { partialStringsSchema } from '$lib/locale.store';
+  import type { partialStyleSchema } from '$lib/style.store';
 
   export let config: z.infer<typeof partialConfigSchema> | undefined = undefined;
-  export let content: z.infer<typeof partialStringsSchema>;
+  export let content: z.infer<typeof partialStringsSchema> | undefined = undefined;
   export let journeys: z.infer<typeof journeyConfigSchema> | undefined = undefined;
   export let links: z.infer<typeof partialLinksSchema> | undefined = undefined;
-  export let style: Style | undefined = undefined;
+  export let style: z.infer<typeof partialStyleSchema> | undefined = undefined;
 
   const dispatch = createEventDispatcher();
 

--- a/src/lib/widget/modal.svelte
+++ b/src/lib/widget/modal.svelte
@@ -3,13 +3,10 @@
 
   import type { z } from 'zod';
 
-  // Import the stores for initialization
-  import configure from '$lib/sdk.config';
   import { widgetApiFactory } from './_utilities/api.utilities';
 
   // Import store types
-  import type { JourneyOptions } from './interfaces';
-  import type { partialConfigSchema } from '$lib/sdk.config';
+  import type { JourneyOptions, Modal } from './interfaces';
 
   import './main.css';
 
@@ -39,7 +36,7 @@
 
   export const configuration = api.configuration;
   export const journey = api.journey;
-  export const modal = api.modal;
+  export const modal = api.modal as Modal;
   export const request = api.request;
   export const user = api.user;
 </script>
@@ -49,6 +46,7 @@
 
   import Dialog from '$components/compositions/dialog/dialog.svelte';
   import Journey from '$journey/journey.svelte';
+  import configure from '$lib/sdk.config';
 
   import { initialize as initializeJourneys } from '$journey/config.store';
   import { initialize as initializeJourney } from '$journey/journey.store';
@@ -58,8 +56,7 @@
   import { initialize as initializeUser } from '$lib/user/user.store';
   import { initialize as initializeStyle, type Style } from '$lib/style.store';
 
-  // Moved config types to module definition ^^
-  // import type { partialConfigSchema } from '$lib/sdk.config';
+  import type { partialConfigSchema } from '$lib/sdk.config';
   import type { journeyConfigSchema } from '$journey/config.store';
   import type { partialStringsSchema } from '$lib/locale.store';
 

--- a/src/lib/widget/modal.svelte
+++ b/src/lib/widget/modal.svelte
@@ -1,20 +1,17 @@
 <script context="module" lang="ts">
-  import {
-    Config,
-    FRUser,
-    type GetTokensOptions,
-    SessionManager,
-    TokenManager,
-    UserManager,
-    HttpClient,
-  } from '@forgerock/javascript-sdk';
-  import type { HttpClientRequestOptions } from '@forgerock/javascript-sdk/lib/http-client';
   import { get } from 'svelte/store';
 
+  import type { z } from 'zod';
+
+  // Import the stores for initialization
+  import configure from '$lib/sdk.config';
+  import { widgetApiFactory } from './_utilities/api.utilities';
+
   // Import store types
-  import type { JourneyOptions, Response } from './interfaces';
-  import type { JourneyStore, JourneyStoreValue } from '$journey/journey.interfaces';
-  import type { OAuthStore, OAuthTokenStoreValue } from '$lib/oauth/oauth.store';
+  import type { JourneyOptions, Response, WidgetApiParams } from './interfaces';
+  import type { JourneyStore } from '$journey/journey.interfaces';
+  import type { OAuthStore } from '$lib/oauth/oauth.store';
+  import type { partialConfigSchema } from '$lib/sdk.config';
   import type { UserStore } from '$lib/user/user.store';
 
   import './main.css';
@@ -23,116 +20,12 @@
   let dialogEl: HTMLDialogElement;
   let callMounted: (dialog: HTMLDialogElement, form: HTMLFormElement) => void;
   let closeCallback: (arg: { reason: 'auto' | 'external' | 'user' }) => void;
-  let journeyStore: JourneyStore;
-  let oauthStore: OAuthStore;
-  let returnError: (response: Response) => void;
-  let returnResponse: (response: Response) => void;
-  let userStore: UserStore;
+  let journeyStore: Maybe<JourneyStore> = null;
+  let oauthStore: Maybe<OAuthStore> = null;
+  let returnError: Maybe<(response: Response) => void> = null;
+  let returnResponse: Maybe<(response: Response) => void> = null;
+  let userStore: Maybe<UserStore> = null;
 
-  export const journey = {
-    start(options?: JourneyOptions): void {
-      const requestsOauth = options?.oauth || true;
-      const requestsUser = options?.user || true;
-
-      let journey: JourneyStoreValue;
-      let oauth: OAuthTokenStoreValue;
-      let journeyStoreUnsub = journeyStore.subscribe((response) => {
-        if (!requestsOauth && response.successful) {
-          returnResponse &&
-            returnResponse({
-              journey: response,
-            });
-          modal.close({ reason: 'auto' });
-        } else if (requestsOauth && response.successful) {
-          journey = response;
-          oauthStore.get({ forceRenew: true });
-        } else if (response.error) {
-          journey = response;
-          returnError &&
-            returnError({
-              journey: response,
-            });
-        }
-        /**
-         * Clean up unneeded subscription, but only when it's successful
-         * Leaving the subscription allows for the journey to be
-         * restarted internally.
-         */
-        if (response.successful) {
-          journeyStoreUnsub();
-        }
-      });
-      let oauthStoreUnsub = oauthStore.subscribe((response) => {
-        if (!requestsUser && response.successful) {
-          returnResponse &&
-            returnResponse({
-              journey,
-              oauth: response,
-            });
-          modal.close({ reason: 'auto' });
-        } else if (requestsUser && response.successful) {
-          oauth = response;
-          userStore.get();
-        } else if (response.error) {
-          oauth = response;
-          returnError &&
-            returnError({
-              journey,
-              oauth: response,
-            });
-        }
-        /**
-         * Clean up unneeded subscription, but only when it's successful
-         * Leaving the subscription allows for the journey to be
-         * restarted internally.
-         */
-        if (response.successful) {
-          oauthStoreUnsub();
-        }
-      });
-      let userStoreUnsub = userStore.subscribe((response) => {
-        if (response.successful) {
-          returnResponse &&
-            returnResponse({
-              journey,
-              oauth,
-              user: response,
-            });
-          modal.close({ reason: 'auto' });
-        } else if (response.error) {
-          returnError &&
-            returnError({
-              journey,
-              oauth,
-              user: response,
-            });
-        }
-        /**
-         * Clean up unneeded subscription, but only when it's successful
-         * Leaving the subscription allows for the journey to be
-         * restarted internally.
-         */
-        if (response.successful) {
-          userStoreUnsub();
-        }
-      });
-
-      if (options?.resumeUrl) {
-        journeyStore.resume(options.resumeUrl);
-      } else {
-        journeyStore.start({
-          ...options?.config,
-          tree: options?.journey,
-        });
-      }
-    },
-    onFailure(fn: (response: Response) => void) {
-      returnError = (response) => fn(response);
-    },
-    onSuccess(fn: (response: Response) => void) {
-      returnResponse = (response) => fn(response);
-    },
-  };
   export const modal = {
     close(args?: { reason: 'auto' | 'external' | 'user' }) {
       dialogComp.closeDialog(args);
@@ -145,65 +38,31 @@
     },
     open(options?: JourneyOptions): void {
       // If journey does not have a step, start the journey
-      if (!get(journeyStore).step) {
+      if (!get(widgetApiParams.journeyStore as JourneyStore).step) {
         journey.start(options);
       }
       dialogEl.showModal();
     },
   };
-  export const request = async (options: HttpClientRequestOptions) => {
-    return await HttpClient.request(options);
+
+  const widgetApiParams: WidgetApiParams = {
+    journeyStore,
+    modal,
+    oauthStore,
+    returnError,
+    returnResponse,
+    userStore,
   };
-  export const user = {
-    async authorized(remote = false) {
-      if (remote) {
-        return !!(await UserManager.getCurrentUser());
-      }
-      return !!(await TokenManager.getTokens());
-    },
-    async info(remote = false) {
-      if (remote) {
-        return await UserManager.getCurrentUser();
-      }
-      return get(userStore).response;
-    },
-    async logout() {
-      const { clientId } = Config.get();
+  export const { configuration, journey, request, user } = widgetApiFactory(widgetApiParams);
 
-      /**
-       * If configuration has a clientId, then use FRUser to logout to ensure
-       * token revoking and removal; else, just end the session.
-       */
-      if (clientId) {
-        // Call SDK logout
-        await FRUser.logout();
-      } else {
-        await SessionManager.logout();
-      }
-
-      // Reset stores
-      journeyStore.reset();
-      oauthStore.reset();
-      userStore.reset();
-
-      // Fetch fresh journey step
-      journey.start();
-    },
-    async tokens(options?: GetTokensOptions) {
-      return await TokenManager.getTokens(options);
-    },
-  };
 </script>
 
 <script lang="ts">
   import { createEventDispatcher, onMount as s_onMount, SvelteComponent } from 'svelte';
-  import type { z } from 'zod';
 
   import Dialog from '$components/compositions/dialog/dialog.svelte';
   import Journey from '$journey/journey.svelte';
 
-  // Import the stores for initialization
-  import configure from '$lib/sdk.config';
   import { initialize as initializeJourneys } from '$journey/config.store';
   import { initialize as initializeJourney } from '$journey/journey.store';
   import { initialize as initializeContent } from '$lib/locale.store';
@@ -212,12 +71,13 @@
   import { initialize as initializeUser } from '$lib/user/user.store';
   import { initialize as initializeStyle, type Style } from '$lib/style.store';
 
-  import type { partialConfigSchema } from '$lib/sdk.config';
+  // Moved config types to module definition ^^
+  // import type { partialConfigSchema } from '$lib/sdk.config';
   import type { journeyConfigSchema } from '$journey/config.store';
-  import type { Maybe } from '$lib/interfaces';
   import type { partialStringsSchema } from '$lib/locale.store';
+  import type { Maybe } from '$lib/interfaces';
 
-  export let config: z.infer<typeof partialConfigSchema>;
+  export let config: z.infer<typeof partialConfigSchema> | undefined = undefined;
   export let content: z.infer<typeof partialStringsSchema>;
   export let journeys: z.infer<typeof journeyConfigSchema> | undefined = undefined;
   export let links: z.infer<typeof partialLinksSchema> | undefined = undefined;
@@ -235,34 +95,36 @@
   // The single refernce to the `form` DOM element
   let formEl: HTMLFormElement;
 
-  // Set base config to SDK
-  // TODO: Move to a shared utility
-  configure({
-    // Set some basics by default
-    ...{
-      // TODO: Could this be a default OAuth client provided by Platform UI OOTB?
-      clientId: 'WebLoginWidgetClient',
-      // TODO: If a realmPath is not provided, should we call the realm endpoint and detect a likely default?
-      // https://backstage.forgerock.com/docs/am/7/setup-guide/sec-rest-realm-rest.html#rest-api-list-realm
-      realmPath: 'alpha',
-      // TODO: Once we move to SSR, this default should be more intelligent
-      redirectUri:
-        typeof window === 'object' ? window.location.href : 'https://localhost:3000/callback',
-      scope: 'openid email',
-    },
-    // Let user provided config override defaults
-    ...config,
-    // Force 'legacy' to remove confusion
-    ...{ support: 'legacy' },
-  });
+  if (config) {
+    // Set base config to SDK
+    // TODO: Move to a shared utility
+    configure({
+      // Set some basics by default
+      ...{
+        // TODO: Could this be a default OAuth client provided by Platform UI OOTB?
+        clientId: 'WebLoginWidgetClient',
+        // TODO: If a realmPath is not provided, should we call the realm endpoint and detect a likely default?
+        // https://backstage.forgerock.com/docs/am/7/setup-guide/sec-rest-realm-rest.html#rest-api-list-realm
+        realmPath: 'alpha',
+        // TODO: Once we move to SSR, this default should be more intelligent
+        redirectUri:
+          typeof window === 'object' ? window.location.href : 'https://localhost:3000/callback',
+        scope: 'openid email',
+      },
+      // Let user provided config override defaults
+      ...config,
+      // Force 'legacy' to remove confusion
+      ...{ support: 'legacy' },
+    });
+  }
 
   /**
    * Initialize the stores and ensure both variables point to the same reference.
    * Variables with _ are the reactive version of the original variable from above.
    */
-  let _journeyStore = (journeyStore = initializeJourney(config));
-  let _oauthStore = (oauthStore = initializeOauth(config));
-  let _userStore = (userStore = initializeUser(config));
+  let _journeyStore = (widgetApiParams.journeyStore = initializeJourney(config));
+  let _oauthStore = (widgetApiParams.oauthStore = initializeOauth(config));
+  let _userStore = (widgetApiParams.userStore = initializeUser(config));
 
   initializeContent(content);
   initializeJourneys(journeys);

--- a/src/routes/docs/widget/full-api/+page.md
+++ b/src/routes/docs/widget/full-api/+page.md
@@ -54,6 +54,75 @@ NOTE: For more SDK configuration options, please [see our SDK's configuration do
 1. For content schema, please [use the example en-US locale file](/src/locales/us/en/index.ts)
 2. For `style` schema and more information, please [see the Style section below](#styling-api)
 
+### Configuration
+
+This object can be useful when you want to leverage APIs that require interaction with the ForgeRock platform or access stored tokens in a location of your app that may not directly use the `Widget`. When the `configuration.set` method is used, it removes the need to set the `config` property within the `Widget` class instantiation.
+
+For example, these would be equivalent:
+
+```js
+import Widget, { configuration } from '@forgerock/login-widget/modal';
+
+// OR, as embedded
+import Widget, { configuration } from 'forgerock-web-login-widget/inline';
+
+// Configuration within Widget instantiation
+const widget = new Widget({
+  target: document.getElementById('widget-root'),
+  props: {
+    config: {
+      /**
+       * REQUIRED; SDK configuration object
+       */
+      serverConfig: {
+        baseUrl: 'https://customer.forgeblocks.com/am',
+      },
+      /**
+       * OPTIONAL, *BUT ENCOURAGED*, CONFIGURATION
+       * Remaining config is optional with fallback values shown
+       */
+      clientId: 'WebLoginWidgetClient',
+      realmPath: 'alpha',
+      redirectUri: window.location.href,
+      scope: 'openid email',
+      tree: 'Login',
+    },
+  },
+});
+```
+
+```js
+import Widget, { configuration } from '@forgerock/login-widget/modal';
+
+// OR, as embedded
+import Widget, { configuration } from 'forgerock-web-login-widget/inline';
+
+// Configuration outside Widget instantiation
+configuration.set({
+  /**
+   * REQUIRED; SDK configuration object
+   */
+  serverConfig: {
+    baseUrl: 'https://customer.forgeblocks.com/am',
+  },
+  /**
+   * OPTIONAL, *BUT ENCOURAGED*, CONFIGURATION
+   * Remaining config is optional with fallback values shown
+   */
+  clientId: 'WebLoginWidgetClient',
+  realmPath: 'alpha',
+  redirectUri: window.location.href,
+  scope: 'openid email',
+  tree: 'Login',
+});
+
+const widget = new Widget({
+  target: document.getElementById('widget-root'),
+});
+```
+
+Note: It's important to not that all methods of the `user` API imported from this module require configuration to be set. So, setting the configuration is best done at the top index or entry file of your application. Then you can use the all APIs without failure.
+
 ## Journey
 
 The `journey` object:

--- a/src/routes/docs/widget/quick-start/+page.md
+++ b/src/routes/docs/widget/quick-start/+page.md
@@ -249,4 +249,38 @@ journey.onSuccess((response) => {
 });
 ```
 
-And, that's it. You now can mount, display, and authenticate users through the ForgeRock Login Widget. There are addition features documented below for a more complete implementation. For more about Widget events, [see the Widget Events section](#widget-events).
+And, that's it. You now can mount, display, and authenticate users through the ForgeRock Login Widget. There are addition features documented within the [Full API section here](/docs/widget/full-api). For more about Widget events, [see the Widget Events section](/docs/widget/full-api#widget-events).
+
+## Checking user information
+
+There are many reasons why you may need user information throughout your application. It may be to display the user's first name or email, it may be to use tokens for protected resources, or to validate an Access Token with the ForgeRock server. Any of these will require the underlying SDK to be configured. To do this, you have two choices:
+
+1. Configure the SDK through `Widget` instantiation
+2. Configure the SDK through the `configuration` object
+
+We've seen [configuring the SDK through `Widget` instantiation](#instantiate-the-widget-modal), but that may not always be preferable as the Widget may not be relevant in all parts of your app. Let's see how we can use the second option instead.
+
+```js
+let userInfo;
+
+// Configure the underlying SDK, so it can communicate with the ForgeRock platform
+configuration.set({
+  clientId: 'WebOAuthClient',
+  redirectUri: `${window.location.origin}/callback`,
+  scope: 'openid profile email me.read',
+  serverConfig: {
+    baseUrl: 'https://example.forgeblocks.com/am/',
+    timeout: 5000,
+  },
+  realmPath: 'alpha',
+});
+
+// Do we have stored tokens
+if (await user.tokens()) {
+  // User has tokens, so attempt call to /userinfo
+  userInfo = await user.info(true);
+} else {
+  // If no tokens, assign null
+  userInfo = null;
+}
+```

--- a/src/routes/e2e/widget/+page.svelte
+++ b/src/routes/e2e/widget/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  import { configuration, user } from '$package/modal';
+
+  let fetchedTokens: any;
+  let userInfo: any;
+
+  async function logout() {
+    await user.logout();
+    userInfo = null;
+  }
+
+  onMount(async () => {
+    configuration.set({
+      clientId: 'WebOAuthClient',
+      redirectUri: `${window.location.origin}/callback`,
+      scope: 'openid profile email me.read',
+      serverConfig: {
+        baseUrl: 'https://openam-crbrl-01.forgeblocks.com/am/',
+        timeout: 5000,
+      },
+      realmPath: 'alpha',
+    });
+
+    // Fetch tokens locally to see if the user has tokens
+    if (await user.tokens()) {
+      fetchedTokens = true;
+      userInfo = await user.info(true);
+    } else {
+      // Set fetched tokens to true so the links render to login
+      fetchedTokens = true;
+    }
+  });
+</script>
+
+
+{#if fetchedTokens}
+  {#if userInfo}
+    <ul>
+      <li id="fullName">
+        <strong>Full name</strong>: {`${userInfo?.given_name} ${userInfo?.family_name}`}
+      </li>
+      <li id="email"><strong>Email</strong>: {userInfo?.email}</li>
+    </ul>
+    <button on:click={logout}>Logout</button>
+  {:else}
+    <ul>
+      <li>
+        <a href="/e2e/widget/modal">Login via Modal Widget</a>
+      </li>
+      <li>
+        <a href="/e2e/widget/inline">Login via Inline Widget</a>
+      </li>
+    </ul>
+  {/if}
+{:else}
+  <p>Loading ... </p>
+{/if}
+
+

--- a/src/routes/e2e/widget/inline/+page.svelte
+++ b/src/routes/e2e/widget/inline/+page.svelte
@@ -18,7 +18,7 @@
     userResponse = null;
   }
 
-  form.onMount((component: HTMLElement) => console.log(component));
+  form.onMount((component) => console.log(component));
   // TODO: Use a more specific type
   journey.onSuccess((response) => (userResponse = response?.user));
   journey.onFailure((response) => console.log(response.journey?.error));

--- a/src/routes/e2e/widget/modal/+page.svelte
+++ b/src/routes/e2e/widget/modal/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
 
-  import Widget, { modal, journey, user } from '$package/modal';
+  import Widget, { configuration, modal, journey, user } from '$package/modal';
   import type { Response } from '$lib/widget/interfaces';
 
   let authIndexValue = $page.url.searchParams.get('authIndexValue');
@@ -42,6 +42,18 @@
 
   onMount(async () => {
     let content;
+
+    configuration.set({
+      clientId: 'WebOAuthClient',
+      redirectUri: `${window.location.origin}/callback`,
+      scope: 'openid profile email me.read',
+      serverConfig: {
+        baseUrl: 'https://openam-crbrl-01.forgeblocks.com/am/',
+        timeout: 5000,
+      },
+      realmPath: 'alpha',
+    });
+
     /**
      * Reuse translated content from locale api if not en-US
      */
@@ -53,16 +65,6 @@
     widget = new Widget({
       target: widgetEl,
       props: {
-        config: {
-          clientId: 'WebOAuthClient',
-          redirectUri: `${window.location.origin}/callback`,
-          scope: 'openid profile email me.read',
-          serverConfig: {
-            baseUrl: 'https://openam-crbrl-01.forgeblocks.com/am/',
-            timeout: 5000,
-          },
-          realmPath: 'alpha',
-        },
         content,
         links: {
           termsAndConditions: 'https://www.forgerock.com/terms',

--- a/src/routes/e2e/widget/modal/+page.svelte
+++ b/src/routes/e2e/widget/modal/+page.svelte
@@ -3,7 +3,6 @@
   import { page } from '$app/stores';
 
   import Widget, { configuration, modal, journey, user } from '$package/modal';
-  import type { Response } from '$lib/widget/interfaces';
 
   let authIndexValue = $page.url.searchParams.get('authIndexValue');
   let journeyParam = $page.url.searchParams.get('journey');
@@ -19,6 +18,7 @@
     userResponse = null;
   }
 
+  // TODO: Investigate why the parameter types are needed here
   modal.onMount((dialog: HTMLDialogElement, form: HTMLFormElement) => {
     console.log(dialog);
     console.log(form);

--- a/tests/widget/modal/widget-modal.login.test.js
+++ b/tests/widget/modal/widget-modal.login.test.js
@@ -5,6 +5,13 @@ import { asyncEvents, verifyUserInfo } from '../../utilities/async-events.js';
 test('Modal widget with login', async ({ page }) => {
   const { clickButton, navigate } = asyncEvents(page);
 
+  // Navigate to page without Widget instantiation
+  await navigate('widget');
+
+  const loginLink = page.getByRole('link', { name: 'Login via Modal Widget' });
+
+  await expect(loginLink).toBeVisible();
+
   await navigate('widget/modal?journey=TEST_Login');
 
   await expect(page.getByRole('dialog')).toBeHidden();
@@ -18,5 +25,14 @@ test('Modal widget with login', async ({ page }) => {
 
   await clickButton('Sign In', '/authenticate');
 
+  await verifyUserInfo(page, expect);
+
+  // Navigate to page without Widget instantiation
+  await navigate('widget');
+
+  // Refresh the page to clear out previous Widget references
+  await page.reload({ waitUntil: 'networkidle' });
+
+  // Test the config and user API without Widget references
   await verifyUserInfo(page, expect);
 });


### PR DESCRIPTION
## Summary

Originally, the Login Widget class instantiation was when the underlying SDK was configured. This prevented key methods from being used separately prior to the Widget itself from being used. This change allows for the configuration to set separate from the Login Widget.

## Details

The underlying SDK can now be configured outside of the Login Widget instantiation. This means the `config` prop of the Widget class is now optional. This PR also includes quite a bit of refactoring at the widget component level. The two form factors (inline and modal) now share the same API generation and logic.