### PR TITLE
docs: update readme and quick start to use beta install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![semantic-release: conventional](https://img.shields.io/badge/semantic--release-conventional-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
-## WARNING: ALPHA VERSION
+## WARNING: BETA VERSION
 
-**This is a early preview (alpha) of a development framework for generating a JavaScript Widget into an existing self-hosted SPA (React, Vue, Angular, etc.). Eventually, this same framework will also generate a ForgeRock Login App for self-hosting. This project is not yet officially supported and is not recommended for any project development. If you use this, you accept all the risks that come with completely unsupported software.**
+**This is a early preview (beta) of a development framework for generating a JavaScript Widget into an existing self-hosted SPA (React, Vue, Angular, etc.). Eventually, this same framework will also generate a ForgeRock Login App for self-hosting. This project is not yet officially supported and is not recommended for any project development. If you use this, you accept all the risks that come with completely unsupported software.**
 
 ## Table of Contents
 
@@ -89,10 +89,10 @@ More details will be discussed below in the [Inline section](#using-the-inline-c
 
 ### Installing the package
 
-Note: **This project is currently in Alpha**, so importing the widget from npm requires the `alpha` tag. Because of this, it's worth noting what's not [currently supported](#currently-unsupported).
+Note: **This project is currently in Beta**, so importing the widget from npm requires the `beta` tag. Because of this, it's worth noting what's not [currently supported](#currently-unsupported).
 
 ```shell
-npm install @forgerock/login-widget@alpha
+npm install @forgerock/login-widget@beta
 ```
 
 ### Adding the Widget's CSS

--- a/src/routes/docs/homepage.md
+++ b/src/routes/docs/homepage.md
@@ -6,7 +6,7 @@
 
 # ForgeRock { data.framework.name }
 
-## WARNING: ALPHA VERSION
+## WARNING: BETA VERSION
 
 **This is a early preview ({ data.package.version }) of a development framework for generating a JavaScript { data.package.name } into an existing self-hosted SPA (React, Vue, Angular, etc.). Eventually, this same framework will also generate a ForgeRock { data.app.name} for self-hosting. This project is not yet officially supported and is not recommended for any project development. If you use this, you accept all the risks that come with completely unsupported software.**
 
@@ -22,7 +22,7 @@ The { data.package.name } produced by this framework is intended to be an all-in
 
 ## ForgeRock { data.package.name }
 
-The Login Widget, currently in alpha, is an embeddable JavaScript component that requires no "runtime" UI libraries or frameworks, allowing it to be used within a React, Angular, Vue, etc. application without any additional dependencies.
+The Login Widget, currently in beta, is an embeddable JavaScript component that requires no "runtime" UI libraries or frameworks, allowing it to be used within a React, Angular, Vue, etc. application without any additional dependencies.
 
 This Widget helps you easily integrate your existing or new apps with the ForgeRock platform and its journeys. It supports the rendering of the built-in nodes and their corresponding callbacks within authentication and self-service journeys. [Please see our "Roadmap" section for current limitations and planned features](/docs/widget/roadmap).
 

--- a/src/routes/docs/widget/quick-start/+page.md
+++ b/src/routes/docs/widget/quick-start/+page.md
@@ -4,10 +4,10 @@ Using the Login Widget within your JavaScript SPA.
 
 ## Installing the package
 
-Note: **This project is currently in Alpha**, so importing the widget from npm requires the `alpha` tag. Because of this, it's worth noting what's not [currently supported](../roadmap/#currently-unsupported).
+Note: **This project is currently in Beta**, so importing the widget from npm requires the `beta` tag. Because of this, it's worth noting what's not [currently supported](../roadmap/#currently-unsupported).
 
 ```shell
-npm install @forgerock/login-widget@alpha
+npm install @forgerock/login-widget@beta
 ```
 
 ## Adding the Widget's CSS


### PR DESCRIPTION
I updated the readme and quick start command snippets to use the beta tag in the install command, to reflect where we are in testing.