### PR TITLE
ci(actions): rebase-beta-after-merge-to-main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,9 @@ jobs:
           VITE_FR_AM_COOKIE_NAME: ${{ secrets.VITE_FR_AM_COOKIE_NAME }}
           VITE_FR_OAUTH_PUBLIC_CLIENT: ${{ secrets.VITE_FR_OAUTH_PUBLIC_CLIENT }}
           VITE_FR_REALM_PATH: ${{ secrets.VITE_FR_REALM_PATH }}
+      - name: rebase beta branch
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git checkout beta
+          git rebase origin main
+          git push origin beta -f


### PR DESCRIPTION
commonly dependabot will create PR's against
main because this is the  target branch set
in github (displayed publicly)  and its annoying to
have to check if main chaniged between   development
cycless. so this is to try to automatically rebase beta
when we merge to main.