### PR TITLE
fix(css/widget-api): fix base link specificity issue & oauth-user disablement

### DIFF
--- a/package/widget.css
+++ b/package/widget.css
@@ -85,7 +85,8 @@ Base link color when inside of localized content.
 --tw-text-opacity: 1;
 color: rgb(37 99 235 / var(--tw-text-opacity));
 }
-:where(.tw_dark) a {
+:where(.tw_dark) :where(.fr_widget-root) a,
+:where(.tw_dark) :where(.fr_widget-root) a {
 --tw-text-opacity: 1;
 color: rgb(96 165 250 / var(--tw-text-opacity));
 }

--- a/package/widget.css
+++ b/package/widget.css
@@ -45,9 +45,22 @@
   -moz-tab-size: 4; /* 3 */
   -o-tab-size: 4;
   tab-size: 4; /* 3 */
-  font-family: 'Open Sans', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', Segoe UI Emoji,
-    Segoe UI Symbol, Noto Color Emoji; /* 4 */
+  font-family:
+    'Open Sans',
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    'Noto Sans',
+    sans-serif,
+    'Apple Color Emoji',
+    Segoe UI Emoji,
+    Segoe UI Symbol,
+    Noto Color Emoji; /* 4 */
 }
 /*
 1. Add the correct height in Firefox.

--- a/src/lib/widget/_utilities/api.utilities.ts
+++ b/src/lib/widget/_utilities/api.utilities.ts
@@ -1,5 +1,10 @@
-import { Config, FRUser, SessionManager, type ConfigOptions } from '@forgerock/javascript-sdk';
-import { HttpClient } from '@forgerock/javascript-sdk';
+import {
+  Config,
+  FRUser,
+  HttpClient,
+  SessionManager,
+  type ConfigOptions,
+} from '@forgerock/javascript-sdk';
 import { derived, get, type Readable } from 'svelte/store';
 
 import { logErrorAndThrow } from '$lib/_utilities/errors.utilities';
@@ -139,8 +144,8 @@ export function widgetApiFactory(componentApi: ReturnType<typeof _componentApi>)
       logErrorAndThrow('missingStores');
     }
 
-    const requestsOauth = options?.oauth || true;
-    const requestsUser = options?.user || true;
+    const requestsOauth = options?.oauth ?? true;
+    const requestsUser = options?.user ?? true;
     const {
       subscribe,
     }: Readable<{ journey: JourneyStoreValue; oauth: OAuthTokenStoreValue; user: UserStoreValue }> =

--- a/src/lib/widget/custom.base.css
+++ b/src/lib/widget/custom.base.css
@@ -31,9 +31,22 @@
   -moz-tab-size: 4; /* 3 */
   -o-tab-size: 4;
   tab-size: 4; /* 3 */
-  font-family: 'Open Sans', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', Segoe UI Emoji,
-    Segoe UI Symbol, Noto Color Emoji; /* 4 */
+  font-family:
+    'Open Sans',
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Helvetica Neue',
+    Arial,
+    'Noto Sans',
+    sans-serif,
+    'Apple Color Emoji',
+    Segoe UI Emoji,
+    Segoe UI Symbol,
+    Noto Color Emoji; /* 4 */
 }
 /*
 1. Add the correct height in Firefox.
@@ -70,7 +83,8 @@ Base link color when inside of localized content.
 :where(.fr_widget-root) a {
   @apply tw_text-link-dark;
 }
-:where(.tw_dark) a {
+:where(.tw_dark) :where(.fr_widget-root) a,
+:where(.tw_dark) :where(.fr_widget-root) a {
   @apply tw_text-link-light;
 }
 /*

--- a/src/routes/e2e/widget/inline/+page.svelte
+++ b/src/routes/e2e/widget/inline/+page.svelte
@@ -3,6 +3,13 @@
   import { page } from '$app/stores';
 
   import Widget, { configuration, component, journey, user } from '$package/index';
+  import type { UserStoreValue } from '$lib/widget/types';
+
+  type UserResponseObj = {
+    family_name: string;
+    given_name: string;
+    email: string;
+  };
 
   const config = configuration();
   const componentEvents = component();
@@ -11,11 +18,9 @@
   let authIndexValueParam = $page.url.searchParams.get('authIndexValue');
   let journeyParam = $page.url.searchParams.get('journey');
   let suspendedIdParam = $page.url.searchParams.get('suspendedId');
-
   let formEl: HTMLDivElement;
-  // TODO: Use a more specific type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let userResponse: { [key: string]: any } | null;
+  let userEvent: UserStoreValue;
+  let userResponse: UserResponseObj | null;
 
   async function logout() {
     await user.logout();
@@ -29,7 +34,8 @@
   });
   journeyEvents.subscribe((event) => {
     if (event?.user?.successful) {
-      userResponse = event.user;
+      userEvent = event.user;
+      userResponse = event.user.response as UserResponseObj;
     }
     if (event.journey.error || event.oauth.error || event.user.error) {
       console.log('Login failure event fired');
@@ -73,13 +79,13 @@
   });
 </script>
 
-{#if userResponse?.successful}
+{#if userEvent?.successful}
   <ul>
     <li id="fullName">
-      <strong>Full name</strong>: {`${userResponse.response?.given_name} ${userResponse.response?.family_name}`}
+      <strong>Full name</strong>: {`${userResponse?.given_name} ${userResponse?.family_name}`}
     </li>
-    <li id="email"><strong>Email</strong>: {userResponse.response?.email}</li>
+    <li id="email"><strong>Email</strong>: {userResponse?.email}</li>
   </ul>
   <button on:click={logout}>Logout</button>
 {/if}
-<div bind:this={formEl} class={`${userResponse?.successful ? 'tw_hidden' : ''} tw_p-6`} />
+<div bind:this={formEl} class={`${userEvent?.successful ? 'tw_hidden' : ''} tw_p-6`} />

--- a/src/routes/e2e/widget/modal/+page.svelte
+++ b/src/routes/e2e/widget/modal/+page.svelte
@@ -12,8 +12,12 @@
   let journeyParam = $page.url.searchParams.get('journey');
   let suspendedIdParam = $page.url.searchParams.get('suspendedId');
 
-  // tslint:disable-next-line: no-any
-  let userResponse: { [key: string]: any } | null;
+  type UserResponseObj = {
+    family_name: string;
+    given_name: string;
+    email: string;
+  };
+  let userResponse: UserResponseObj | null;
   let widgetEl: HTMLDivElement;
 
   async function logout() {
@@ -32,7 +36,7 @@
   journeyEvents.subscribe((event) => {
     if (event?.user?.successful) {
       console.log(event.user);
-      userResponse = event.user;
+      userResponse = event.user.response as UserResponseObj;
     }
     if (event.journey.error || event.oauth.error || event.user.error) {
       console.log('Login failure event fired');
@@ -125,9 +129,9 @@
   {#if userResponse}
     <ul>
       <li id="fullName">
-        <strong>Full name</strong>: {`${userResponse.response?.given_name} ${userResponse.response?.family_name}`}
+        <strong>Full name</strong>: {`${userResponse?.given_name} ${userResponse?.family_name}`}
       </li>
-      <li id="email"><strong>Email</strong>: {userResponse.response?.email}</li>
+      <li id="email"><strong>Email</strong>: {userResponse?.email}</li>
     </ul>
     <button on:click={logout}>Logout</button>
   {:else}


### PR DESCRIPTION
- fixes a bug where a CSS selector for links are not targeted enough, leading to unintended styling of non-widget elements
- fix disabling `user` and `oauth` requests through `journey()` initialization for widget API
- consolidate the import of SDK in `api.utilities.ts`
- fix type issues in both e2e test pages: inline and modal