### PR TITLE
refactor(npm-package): use-package-instead-of-alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@forgerock/javascript-sdk": "beta",
+        "@forgerock/login-widget": "./package",
         "qrcode": "1.5.3",
         "xss": "1.0.14",
         "zod": "3.22.4"
@@ -2544,6 +2545,10 @@
       "version": "4.3.0-beta.1",
       "resolved": "https://registry.npmjs.org/@forgerock/javascript-sdk/-/javascript-sdk-4.3.0-beta.1.tgz",
       "integrity": "sha512-MRqXuTTrwIQlIeFBL7Og4KmQ1FIy1sYq0xc0NyzEdPD229+O+irorOURXKwYRxhD9TW8Hy7WLBM3CpMVaeW9/g=="
+    },
+    "node_modules/@forgerock/login-widget": {
+      "resolved": "package",
+      "link": true
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -37138,6 +37143,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "package": {
+      "version": "1.2.0-beta.11",
+      "dev": true,
+      "license": "MIT"
     }
   },
   "dependencies": {
@@ -38778,6 +38788,9 @@
       "version": "4.3.0-beta.1",
       "resolved": "https://registry.npmjs.org/@forgerock/javascript-sdk/-/javascript-sdk-4.3.0-beta.1.tgz",
       "integrity": "sha512-MRqXuTTrwIQlIeFBL7Og4KmQ1FIy1sYq0xc0NyzEdPD229+O+irorOURXKwYRxhD9TW8Hy7WLBM3CpMVaeW9/g=="
+    },
+    "@forgerock/login-widget": {
+      "version": "file:package"
     },
     "@hapi/hoek": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@babel/core": "^7.21.3",
     "@hcaptcha/types": "^1.0.3",
+    "@forgerock/login-widget": "./package",
     "@playwright/test": "^1.39.0",
     "@rollup/plugin-alias": "^5.0.0",
     "@rollup/plugin-commonjs": "^24.0.1",

--- a/package/index.js
+++ b/package/index.js
@@ -1,13 +1,13 @@
 /**
  * @forgerock/login-widget
  *
- * Copyright (c) 2023 ForgeRock. All rights reserved.
+ * Copyright (c) 2024 ForgeRock. All rights reserved.
  * This software may be modified and distributed under the terms
  * of the MIT license.
  *
  * MIT License
  *
- * Copyright (c) 2023
+ * Copyright (c) 2024
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/routes/e2e/+layout.svelte
+++ b/src/routes/e2e/+layout.svelte
@@ -2,7 +2,7 @@
   /**
    * TODO: If there's a better way to do this, change to it
    */
-  import '$package/widget.css';
+  import '@forgerock/login-widget/widget.css';
 </script>
 
 <svelte:head>

--- a/src/routes/e2e/widget/+page.svelte
+++ b/src/routes/e2e/widget/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
 
-  import { configuration, user } from '$package/index';
+  import { configuration, user } from '@forgerock/login-widget';
 
   let loading: unknown;
   let userInfo: Record<string, unknown> | null;

--- a/src/routes/e2e/widget/inline/+page.svelte
+++ b/src/routes/e2e/widget/inline/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
 
-  import Widget, { configuration, component, journey, user } from '$package/index';
+  import Widget, { configuration, component, journey, user } from '@forgerock/login-widget';
   import type { UserStoreValue } from '$lib/widget/types';
 
   type UserResponseObj = {

--- a/src/routes/e2e/widget/modal/+page.svelte
+++ b/src/routes/e2e/widget/modal/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
 
-  import Widget, { configuration, component, journey, user } from '$package/index';
+  import Widget, { configuration, component, journey, user } from '@forgerock/login-widget';
 
   const config = configuration();
   const componentEvents = component();


### PR DESCRIPTION
use an npm package reference instead of a alias for more real usage