### PR TITLE
Handle Failure URL SDKS-4102

### DIFF
--- a/core/journey/journey.interfaces.ts
+++ b/core/journey/journey.interfaces.ts
@@ -13,6 +13,7 @@ import type {
   FRLoginSuccess,
   Step,
   StepOptions,
+  StepDetail,
 } from '@forgerock/javascript-sdk';
 import type { Writable } from 'svelte/store';
 import type { Maybe } from '$core/interfaces';
@@ -58,6 +59,7 @@ export interface JourneyStoreValue {
     message: Maybe<string>;
     stage: Maybe<string>;
     troubleshoot: Maybe<string>;
+    detail: Maybe<StepDetail>;
   }>;
   loading: boolean;
   metadata: {

--- a/core/journey/journey.store.ts
+++ b/core/journey/journey.store.ts
@@ -340,6 +340,7 @@ export function initialize(initOptions?: StepOptions): JourneyStore {
             message: failureMessageStr,
             stage: prevStep?.payload?.stage,
             troubleshoot: null,
+            detail: nextStep.payload?.detail,
           },
           loading: false,
           metadata: {
@@ -370,6 +371,7 @@ export function initialize(initOptions?: StepOptions): JourneyStore {
             message: failureMessageStr,
             stage: prevStep?.payload?.stage,
             troubleshoot: null,
+            detail: nextStep.payload?.detail,
           },
           loading: false,
           metadata: null,


### PR DESCRIPTION
### Ticket
https://pingidentity.atlassian.net/browse/SDKS-4102

### Details
Added detail property to error object to show failure url in journey
Had a conversation with Ryan about failing Ping Protect tests. The tests are failing because those journeys don't exist. Created a separate ticket for this: https://pingidentity.atlassian.net/browse/SDKS-4823

### How to test?
This can be tested locally by starting the login widget and using the `Vatsal Login` journey: https://localhost:8443/?journey=Vatsal%20Login, because testing this ticket requires a journey that contains the `Failure URL` node

<img width="3438" height="1442" alt="Screenshot 2026-03-04 at 3 27 12 PM" src="https://github.com/user-attachments/assets/e4acc0de-7154-4ed7-a148-39652473a809" />

