### PR TITLE
fix(ci): use corepack for npm and patch picomatch CVEs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,14 @@ jobs:
           # Setting registry-url creates an .npmrc with _authToken=${NODE_AUTH_TOKEN},
           # which prevents OIDC fallback even when the env var is unset.
 
-      # Node 22.x ships with npm 10.x; OIDC trusted publishing requires npm >= 11.5.1
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@^11.6.0
+      # Node 22.x ships npm 10.x; OIDC trusted publishing requires npm >= 11.6.
+      # Use corepack to install the required npm version instead of self-upgrading
+      # npm, which can fail on runners with corrupted pre-installed npm.
+      - name: Install npm for OIDC trusted publishing
+        run: |
+          corepack enable npm
+          corepack install -g npm@latest
+          npm --version
 
       - run: pnpm install --frozen-lockfile
 
@@ -159,8 +164,11 @@ jobs:
           node-version: 22.x
           cache: 'pnpm'
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@^11.6.0
+      - name: Install npm for OIDC trusted publishing
+        run: |
+          corepack enable npm
+          corepack install -g npm@latest
+          npm --version
 
       - run: pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
     }
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["@swc/core", "esbuild", "svelte-preprocess", "unrs-resolver"]
+    "onlyBuiltDependencies": ["@swc/core", "esbuild", "svelte-preprocess", "unrs-resolver"],
+    "overrides": {
+      "picomatch@2": "2.3.2",
+      "picomatch@4": "4.0.4"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite>rollup: npm:@rollup/wasm-node
+  picomatch@2: 2.3.2
+  picomatch@4: 4.0.4
 
 importers:
 
@@ -182,7 +183,7 @@ importers:
         version: 5.53.7
       svelte-check:
         specifier: ^4.4.5
-        version: 4.4.5(picomatch@4.0.3)(svelte@5.53.7)(typescript@5.9.3)
+        version: 4.4.5(picomatch@4.0.4)(svelte@5.53.7)(typescript@5.9.3)
       svelte-preprocess:
         specifier: ^6.0.3
         version: 6.0.3(@babel/core@7.29.0)(postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8)(yaml@2.8.2))(postcss@8.5.8)(svelte@5.53.7)(typescript@5.9.3)
@@ -300,7 +301,7 @@ importers:
         version: 5.53.7
       svelte-check:
         specifier: ^4.4.5
-        version: 4.4.5(picomatch@4.0.3)(svelte@5.53.7)(typescript@5.9.3)
+        version: 4.4.5(picomatch@4.0.4)(svelte@5.53.7)(typescript@5.9.3)
       svelte-loader:
         specifier: ^3.2.4
         version: 3.2.4(svelte@5.53.7)
@@ -2874,7 +2875,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -4062,12 +4063,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pidtree@0.6.0:
@@ -6159,10 +6160,10 @@ snapshots:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       is-reference: 1.2.1
       magic-string: 0.30.21
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.59.0
 
@@ -6186,7 +6187,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.59.0
 
@@ -7183,7 +7184,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   append-transform@2.0.0:
     dependencies:
@@ -8106,9 +8107,9 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fflate@0.8.2: {}
 
@@ -9011,7 +9012,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   jest-validate@30.2.0:
     dependencies:
@@ -9304,7 +9305,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -9565,9 +9566,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
 
@@ -9784,7 +9785,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 
@@ -10181,11 +10182,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.4.5(picomatch@4.0.3)(svelte@5.53.7)(typescript@5.9.3):
+  svelte-check@4.4.5(picomatch@4.0.4)(svelte@5.53.7)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.53.7
@@ -10355,8 +10356,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 
@@ -10483,7 +10484,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   unrs-resolver@1.11.1:
@@ -10616,7 +10617,7 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2


### PR DESCRIPTION
## Summary

- **Corepack for npm**: Replace `npm install -g npm@^11.6.0` with `corepack enable npm && corepack install -g npm@latest` in both `release` and `snapshot` jobs. The pre-installed npm on GitHub runners can have corrupted dependencies (`MODULE_NOT_FOUND` for `promise-retry`), breaking self-upgrade. Corepack downloads npm directly from the registry, bypassing the broken bootstrap.
- **Picomatch CVE fixes**: Add pnpm overrides to force `picomatch@2.3.2` and `picomatch@4.0.4`, resolving CVE-2026-33671 (High 7.5) and CVE-2026-33672 (Medium 5.3).

## Test plan

- [ ] Verify CI release workflow runs successfully with corepack-based npm install
- [ ] Verify snapshot workflow dispatch works with corepack-based npm install
- [ ] Confirm `npm --version` in CI logs shows >= 11.6.0
- [ ] Confirm no vulnerable picomatch versions remain in lockfile