### PR TITLE
Fix corepack ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       # npm, which can fail on runners with corrupted pre-installed npm.
       - name: Install npm for OIDC trusted publishing
         run: |
-          corepack enable npm
+          corepack enable
           corepack install -g npm@latest
           npm --version
 


### PR DESCRIPTION
corepack enable npm breaks because its a pnpm workspace but corepack enable without specifying works it seems.