### PR TITLE
fix(ci): use Node 24.x for npm 11.x OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,20 +50,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'pnpm'
           # No registry-url — OIDC trusted publishing handles auth without NODE_AUTH_TOKEN.
           # Setting registry-url creates an .npmrc with _authToken=${NODE_AUTH_TOKEN},
           # which prevents OIDC fallback even when the env var is unset.
-
-      # Node 22.x ships npm 10.x; OIDC trusted publishing requires npm >= 11.6.
-      # Use corepack to install the required npm version instead of self-upgrading
-      # npm, which can fail on runners with corrupted pre-installed npm.
-      - name: Install npm for OIDC trusted publishing
-        run: |
-          corepack enable
-          corepack install -g npm@latest
-          npm --version
 
       - run: pnpm install --frozen-lockfile
 
@@ -161,14 +152,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'pnpm'
-
-      - name: Install npm for OIDC trusted publishing
-        run: |
-          corepack enable
-          corepack install -g npm@latest
-          npm --version
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- Switches release workflow from Node 22.x to 24.x, which ships with npm 11.x natively
- Removes broken `corepack install -g npm@latest` steps — corepack only manages pnpm/yarn, not npm
- Fixes trusted publishing failures caused by npm 10.x (OIDC requires >= 11.6)

## Test plan
- [ ] Trigger a workflow_dispatch snapshot publish to verify npm version and OIDC auth
- [ ] Merge a changeset to main and confirm the release job succeeds