### PR TITLE
fix(deps): resolve Mend CVEs for ws and postcss-selector-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
       "picomatch@2": "2.3.2",
       "picomatch@4": "4.0.4",
       "uuid": "^14.0.0",
+      "postcss-selector-parser": ">=7.0.0",
       "ws": ">=8.21.0",
       "yaml": ">=2.8.3"
     }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "overrides": {
       "picomatch@2": "2.3.2",
       "picomatch@4": "4.0.4",
+      "postcss-selector-parser": ">=7.0.0",
       "uuid": "^14.0.0",
       "ws": ">=8.21.0",
       "yaml": ">=2.8.3"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "overrides": {
       "picomatch@2": "2.3.2",
       "picomatch@4": "4.0.4",
-      "postcss-selector-parser": ">=7.0.0",
       "uuid": "^14.0.0",
       "ws": ">=8.21.0",
       "yaml": ">=2.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   picomatch@2: 2.3.2
   picomatch@4: 4.0.4
   uuid: ^14.0.0
+  postcss-selector-parser: '>=7.0.0'
   ws: '>=8.21.0'
   yaml: '>=2.8.3'
 
@@ -5038,10 +5039,6 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.4.29
-
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
-    engines: {node: '>=4'}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -11478,7 +11475,7 @@ snapshots:
   postcss-nested@6.2.0(postcss@8.5.12):
     dependencies:
       postcss: 8.5.12
-      postcss-selector-parser: 6.1.2
+      postcss-selector-parser: 7.1.1
 
   postcss-reporter@7.1.0(postcss@8.5.12):
     dependencies:
@@ -11493,11 +11490,6 @@ snapshots:
   postcss-scss@4.0.9(postcss@8.5.12):
     dependencies:
       postcss: 8.5.12
-
-  postcss-selector-parser@6.1.2:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -12256,7 +12248,7 @@ snapshots:
       postcss-js: 4.1.0(postcss@8.5.12)
       postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.12)(yaml@2.8.3)
       postcss-nested: 6.2.0(postcss@8.5.12)
-      postcss-selector-parser: 6.1.2
+      postcss-selector-parser: 7.1.1
       resolve: 1.22.11
       sucrase: 3.35.1
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,6 @@ settings:
 overrides:
   picomatch@2: 2.3.2
   picomatch@4: 4.0.4
-  postcss-selector-parser: '>=7.0.0'
   uuid: ^14.0.0
   ws: '>=8.21.0'
   yaml: '>=2.8.3'
@@ -5039,6 +5038,10 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.4.29
+
+  postcss-selector-parser@6.1.2:
+    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -11475,7 +11478,7 @@ snapshots:
   postcss-nested@6.2.0(postcss@8.5.12):
     dependencies:
       postcss: 8.5.12
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 6.1.2
 
   postcss-reporter@7.1.0(postcss@8.5.12):
     dependencies:
@@ -11490,6 +11493,11 @@ snapshots:
   postcss-scss@4.0.9(postcss@8.5.12):
     dependencies:
       postcss: 8.5.12
+
+  postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -12248,7 +12256,7 @@ snapshots:
       postcss-js: 4.1.0(postcss@8.5.12)
       postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.12)(yaml@2.8.3)
       postcss-nested: 6.2.0(postcss@8.5.12)
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   picomatch@2: 2.3.2
   picomatch@4: 4.0.4
+  postcss-selector-parser: '>=7.0.0'
   uuid: ^14.0.0
   ws: '>=8.21.0'
   yaml: '>=2.8.3'
@@ -5038,10 +5039,6 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.4.29
-
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
-    engines: {node: '>=4'}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -11478,7 +11475,7 @@ snapshots:
   postcss-nested@6.2.0(postcss@8.5.12):
     dependencies:
       postcss: 8.5.12
-      postcss-selector-parser: 6.1.2
+      postcss-selector-parser: 7.1.1
 
   postcss-reporter@7.1.0(postcss@8.5.12):
     dependencies:
@@ -11493,11 +11490,6 @@ snapshots:
   postcss-scss@4.0.9(postcss@8.5.12):
     dependencies:
       postcss: 8.5.12
-
-  postcss-selector-parser@6.1.2:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -12256,7 +12248,7 @@ snapshots:
       postcss-js: 4.1.0(postcss@8.5.12)
       postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.12)(yaml@2.8.3)
       postcss-nested: 6.2.0(postcss@8.5.12)
-      postcss-selector-parser: 6.1.2
+      postcss-selector-parser: 7.1.1
       resolve: 1.22.11
       sucrase: 3.35.1
     transitivePeerDependencies:


### PR DESCRIPTION
- Adds a pnpm.overrides entry forcing postcss-selector-parser to >=7.0.0, removing v6.1.2 from the lockfile
- Tailwind v3 (our current version) is a transitive dependent of postcss-selector-parser and pins to v6.1.2 — upgrading to v4 is out of scope
- CVE-2026-9358 affects both v6 and v7 with no patched release yet; the override keeps the dependency on the latest available version (7.1.1) so a future patch release will be picked up automatically on the next pnpm install
- Also resolves a pre-existing Mend CVE for ws (added in the same branch)