### PR TITLE
SDKS-5079: Add IDM Theming Support to Widget and Login App

### DIFF
--- a/.changeset/idm-theming-support.md
+++ b/.changeset/idm-theming-support.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/login-widget': minor
+---
+
+Add IDM theming support. Consumers can now pass a `theme` object to `configuration({ style: { theme } })` to apply design tokens as CSS custom properties on the widget root. Supports `primaryColor`, `secondaryColor`, `backgroundColor`, `linkColor`, `linkActiveColor`, `fontFamily`, `buttonBorderRadius`, `cardBorderRadius`, `cardBgColor`, `inputBgColor`, `inputBorderColor`, `inputLabelColor`, `inputTextColor`, `inputFocusRingColor`, `selectAccentColor`, `selectHoverBgColor`, `cardTextColor`, `bodyTextColor`, `buttonTextColor`, `buttonFocusRingColor`, `logo`, `logoHeight`, and `primaryOffColor`. The Login App SSR layer fetches theme values from the IDM `/openidm/config/ui/themerealm` endpoint automatically.

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -4,6 +4,7 @@ FR_AM_COOKIE_NAME=iPlanetDirectoryPro
 FR_OAUTH_PUBLIC_CLIENT=WebLoginWidgetClient
 FR_REALM_PATH=alpha
 # FR_OAUTH_SCOPE=openid profile me.read  # optional — AM uses client defaults if omitted
+# FR_AM_JOURNEY_LOGIN=Login  # optional — default login journey name; used for IDM theme resolution when no ?journey= param is present
 
 # BFF session signing (required for cookie HMAC)
 COOKIE_SECRET=<<<(string) At least 32 characters for HMAC signing>>>

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ FR_REALM_PATH=<<<(string) Realm path of AM>>>
 FR_OAUTH_PUBLIC_CLIENT=<<<(string) Your Public OAuth client name/ID>>>
 # FR_OAUTH_SCOPE=openid profile me.read  # optional — AM uses client defaults if omitted
 FR_AM_WELLKNOWN_URL=<<<(string) Your OIDC Discovery Wellknown Endpoint>>>
+# FR_AM_JOURNEY_LOGIN=Login  # optional — default login journey name; used for IDM theme resolution when no ?journey= param is present
 
 # BFF session signing
 COOKIE_SECRET=<<<(string) At least 32 characters for HMAC signing>>>

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,5 @@
 engine-strict=false
 auto-install-peers=true
 strict-peer-dependencies=false
+public-hoist-pattern[]=@effect/*
+public-hoist-pattern[]=effect

--- a/apps/login-app/src/lib/server/idm-theme.effects.test.ts
+++ b/apps/login-app/src/lib/server/idm-theme.effects.test.ts
@@ -1,0 +1,245 @@
+/**
+ *
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({ env: { FR_IDM_THEME_TIMEOUT_MS: undefined } }));
+import type * as StyleStore from '$core/style.store';
+
+vi.mock('$core/style.store', async () => {
+  const actual = await vi.importActual<typeof StyleStore>('$core/style.store');
+  return actual;
+});
+
+import { fetchIdmTheme } from './idm-theme.effects';
+
+const IDM_URL = 'https://idm.example.com';
+const REALM = 'alpha';
+
+const makeThemeEntry = (overrides: Record<string, unknown> = {}) => ({
+  isDefault: true,
+  linkedTrees: [] as string[],
+  primaryColor: '#cc0000',
+  ...overrides,
+});
+
+const makeResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchIdmTheme', () => {
+  describe('successful fetch', () => {
+    it('returns theme for the default entry', async () => {
+      vi.mocked(fetch).mockResolvedValue(makeResponse({ realm: { [REALM]: [makeThemeEntry()] } }));
+
+      const result = await fetchIdmTheme(IDM_URL, REALM, null);
+
+      expect(result.theme?.primaryColor).toBe('#cc0000');
+      expect(result.backgroundImageUrl).toBeUndefined();
+    });
+
+    it('prefers journey-linked theme over default', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        makeResponse({
+          realm: {
+            [REALM]: [
+              makeThemeEntry({ isDefault: false, linkedTrees: ['Login'], primaryColor: '#0000ff' }),
+              makeThemeEntry({ isDefault: true, primaryColor: '#cc0000' }),
+            ],
+          },
+        }),
+      );
+
+      const result = await fetchIdmTheme(IDM_URL, REALM, 'Login');
+
+      expect(result.theme?.primaryColor).toBe('#0000ff');
+    });
+
+    it('falls back to default theme when journey name does not match', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        makeResponse({
+          realm: {
+            [REALM]: [
+              makeThemeEntry({ isDefault: false, linkedTrees: ['Registration'] }),
+              makeThemeEntry({ isDefault: true, primaryColor: '#aabbcc' }),
+            ],
+          },
+        }),
+      );
+
+      const result = await fetchIdmTheme(IDM_URL, REALM, 'Login');
+
+      expect(result.theme?.primaryColor).toBe('#aabbcc');
+    });
+
+    it('falls back to first theme when no default and no journey match', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        makeResponse({
+          realm: {
+            [REALM]: [makeThemeEntry({ isDefault: false, primaryColor: '#112233' })],
+          },
+        }),
+      );
+
+      const result = await fetchIdmTheme(IDM_URL, REALM, null);
+
+      expect(result.theme?.primaryColor).toBe('#112233');
+    });
+
+    it('extracts backgroundImageUrl when valid', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        makeResponse({
+          realm: {
+            [REALM]: [makeThemeEntry({ backgroundImage: 'https://example.com/bg.png' })],
+          },
+        }),
+      );
+
+      const result = await fetchIdmTheme(IDM_URL, REALM, null);
+
+      expect(result.backgroundImageUrl).toBe('https://example.com/bg.png');
+    });
+
+    it('omits backgroundImageUrl for non-URL backgroundImage values', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        makeResponse({
+          realm: {
+            [REALM]: [makeThemeEntry({ backgroundImage: '../relative/path.png' })],
+          },
+        }),
+      );
+
+      const result = await fetchIdmTheme(IDM_URL, REALM, null);
+
+      expect(result.backgroundImageUrl).toBeUndefined();
+    });
+
+    it('returns undefined theme when no themes exist for realm', async () => {
+      vi.mocked(fetch).mockResolvedValue(makeResponse({ realm: {} }));
+
+      const result = await fetchIdmTheme(IDM_URL, 'realm-empty', null);
+
+      expect(result.theme).toBeUndefined();
+      expect(result.backgroundImageUrl).toBeUndefined();
+    });
+
+    it('constructs IDM URL from base URL correctly', async () => {
+      vi.mocked(fetch).mockResolvedValue(makeResponse({ realm: {} }));
+
+      await fetchIdmTheme('https://openam.example.com/am/', REALM, null);
+
+      expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+        'https://openam.example.com/openidm/config/ui/themerealm',
+        expect.objectContaining({ headers: { Accept: 'application/json' } }),
+      );
+    });
+
+    it('drops invalid hex colors gracefully via themeSchema', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        makeResponse({
+          realm: {
+            [REALM]: [makeThemeEntry({ primaryColor: 'not-a-hex' })],
+          },
+        }),
+      );
+
+      const result = await fetchIdmTheme(IDM_URL, REALM, null);
+
+      expect(result.theme?.primaryColor).toBeUndefined();
+    });
+  });
+
+  describe('failure handling', () => {
+    it('returns empty result on fetch network error (no cache)', async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error('network failure'));
+
+      const result = await fetchIdmTheme(IDM_URL, 'realm-no-cache-net', null);
+
+      expect(result.theme).toBeUndefined();
+      expect(result.backgroundImageUrl).toBeUndefined();
+    });
+
+    it('returns empty result on non-ok response (no cache)', async () => {
+      vi.mocked(fetch).mockResolvedValue(new Response('', { status: 500 }));
+
+      const result = await fetchIdmTheme(IDM_URL, 'realm-no-cache-500', null);
+
+      expect(result.theme).toBeUndefined();
+    });
+
+    it('returns empty result on invalid JSON (no cache)', async () => {
+      vi.mocked(fetch).mockResolvedValue(new Response('not json', { status: 200 }));
+
+      const result = await fetchIdmTheme(IDM_URL, 'realm-no-cache-json', null);
+
+      expect(result.theme).toBeUndefined();
+    });
+
+    it('returns cached result on network failure after successful fetch', async () => {
+      const cacheRealm = 'realm-cache-net-fail';
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeResponse({ realm: { [cacheRealm]: [makeThemeEntry({ primaryColor: '#facade' })] } }),
+      );
+      await fetchIdmTheme(IDM_URL, cacheRealm, null);
+
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('network failure'));
+      const result = await fetchIdmTheme(IDM_URL, cacheRealm, null);
+
+      expect(result.theme?.primaryColor).toBe('#facade');
+    });
+
+    it('returns cached result on 500 after successful fetch', async () => {
+      const cacheRealm = 'realm-cache-500';
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        makeResponse({ realm: { [cacheRealm]: [makeThemeEntry({ primaryColor: '#abcdef' })] } }),
+      );
+      await fetchIdmTheme(IDM_URL, cacheRealm, null);
+
+      vi.mocked(fetch).mockResolvedValueOnce(new Response('', { status: 500 }));
+      const result = await fetchIdmTheme(IDM_URL, cacheRealm, null);
+
+      expect(result.theme?.primaryColor).toBe('#abcdef');
+    });
+
+    it('uses separate cache entries for different journey names', async () => {
+      const cacheRealm = 'realm-cache-journey';
+
+      const body = {
+        realm: {
+          [cacheRealm]: [
+            makeThemeEntry({ isDefault: false, linkedTrees: ['Login'], primaryColor: '#111111' }),
+            makeThemeEntry({ isDefault: true, linkedTrees: [], primaryColor: '#222222' }),
+          ],
+        },
+      };
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(makeResponse(body))
+        .mockResolvedValueOnce(makeResponse(body));
+
+      const loginResult = await fetchIdmTheme(IDM_URL, cacheRealm, 'Login');
+      const defaultResult = await fetchIdmTheme(IDM_URL, cacheRealm, null);
+
+      expect(loginResult.theme?.primaryColor).toBe('#111111');
+      expect(defaultResult.theme?.primaryColor).toBe('#222222');
+    });
+  });
+});

--- a/apps/login-app/src/lib/server/idm-theme.effects.ts
+++ b/apps/login-app/src/lib/server/idm-theme.effects.ts
@@ -1,0 +1,158 @@
+/**
+ *
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { type ThemeObject, themeSchema, urlRegex } from '$core/style.store';
+import { env } from '$env/dynamic/private';
+
+interface IdmThemeEntry {
+  isDefault?: boolean;
+  linkedTrees?: string[];
+  primaryColor?: string;
+  primaryOffColor?: string;
+  secondaryColor?: string;
+  backgroundColor?: string;
+  backgroundImage?: string;
+  linkColor?: string;
+  linkActiveColor?: string;
+  buttonRounded?: number | string;
+  favicon?: string;
+  logo?: string;
+  logoHeight?: number | string;
+  fontFamily?: string;
+  journeyCardBorderRadius?: number | string;
+  journeyCardBackgroundColor?: string;
+  journeyInputBackgroundColor?: string;
+  journeyInputBorderColor?: string;
+  journeyInputLabelColor?: string;
+  journeyInputFocusBorderColor?: string;
+  journeyInputSelectColor?: string;
+  journeyInputSelectHoverColor?: string;
+  buttonFocusBorderColor?: string;
+  journeyInputTextColor?: string;
+  journeyCardTextColor?: string;
+  bodyText?: string;
+  textColor?: string;
+}
+
+interface IdmThemeRealmResponse {
+  realm?: Record<string, IdmThemeEntry[]>;
+}
+
+export interface IdmThemeResult {
+  theme: ThemeObject | undefined;
+  backgroundImageUrl: string | undefined;
+}
+
+/**
+ * Theme fetches block SSR rendering, so the IDM request is given a short
+ * timeout. On any failure the last successful result for the same
+ * realm + journey is reused, which is more accurate than falling back to the
+ * widget defaults. The cache is module-level and lives for the server process.
+ *
+ * The default of 1500ms covers a co-located login-app/IDM deployment where the
+ * themerealm payload (~136KB) can take 300-500ms. For tighter latency budgets,
+ * lower it via `FR_IDM_THEME_TIMEOUT_MS`.
+ */
+const DEFAULT_IDM_FETCH_TIMEOUT_MS = 1500;
+const themeCache = new Map<string, IdmThemeResult>();
+
+function resolveTimeoutMs(): number {
+  const parsed = Number(env.FR_IDM_THEME_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_IDM_FETCH_TIMEOUT_MS;
+}
+
+function toIdmTheme(entry: IdmThemeEntry): ThemeObject | undefined {
+  const raw = {
+    primaryColor: entry.primaryColor,
+    primaryOffColor: entry.primaryOffColor,
+    secondaryColor: entry.secondaryColor,
+    backgroundColor: entry.backgroundColor,
+    linkColor: entry.linkColor,
+    linkActiveColor: entry.linkActiveColor,
+    favicon: urlRegex.test(entry.favicon ?? '') ? entry.favicon : undefined,
+    logo: entry.logo,
+    logoHeight: entry.logoHeight !== undefined ? Number(entry.logoHeight) : undefined,
+    fontFamily: entry.fontFamily,
+    buttonBorderRadius: entry.buttonRounded !== undefined ? Number(entry.buttonRounded) : undefined,
+    cardBorderRadius:
+      entry.journeyCardBorderRadius !== undefined
+        ? Number(entry.journeyCardBorderRadius)
+        : undefined,
+    cardBgColor: entry.journeyCardBackgroundColor,
+    inputBgColor: entry.journeyInputBackgroundColor,
+    inputBorderColor: entry.journeyInputBorderColor,
+    inputLabelColor: entry.journeyInputLabelColor,
+    inputFocusRingColor: entry.journeyInputFocusBorderColor,
+    selectAccentColor: entry.journeyInputSelectColor,
+    selectHoverBgColor: entry.journeyInputSelectHoverColor,
+    buttonFocusRingColor: entry.buttonFocusBorderColor,
+    inputTextColor: entry.journeyInputTextColor,
+    cardTextColor: entry.journeyCardTextColor,
+    bodyTextColor: entry.bodyText,
+    buttonTextColor: entry.textColor,
+  };
+  return themeSchema.safeParse(raw).data ?? undefined;
+}
+
+export async function fetchIdmTheme(
+  idmBaseUrl: string,
+  realmPath: string,
+  journeyName: string | null,
+): Promise<IdmThemeResult> {
+  const url = new URL('/openidm/config/ui/themerealm', idmBaseUrl).href;
+  const cacheKey = `${realmPath}::${journeyName ?? ''}`;
+  const cached = themeCache.get(cacheKey);
+  const emptyResult: IdmThemeResult = { theme: undefined, backgroundImageUrl: undefined };
+  let response: Response;
+
+  try {
+    response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(resolveTimeoutMs()),
+    });
+  } catch {
+    console.warn(`[theming] IDM fetch failed: ${url}`);
+    return cached ?? emptyResult;
+  }
+
+  if (!response.ok) {
+    console.warn(`[theming] IDM returned ${response.status} for ${url}`);
+    return cached ?? emptyResult;
+  }
+
+  let body: IdmThemeRealmResponse;
+  try {
+    body = (await response.json()) as IdmThemeRealmResponse;
+  } catch {
+    console.warn('[theming] IDM response was not valid JSON');
+    return cached ?? emptyResult;
+  }
+
+  const themes = body.realm?.[realmPath] ?? [];
+
+  const matched =
+    (journeyName && themes.find((theme) => theme.linkedTrees?.includes(journeyName))) ??
+    themes.find((theme) => theme.isDefault) ??
+    themes[0];
+
+  if (!matched) return cached ?? emptyResult;
+
+  const backgroundImageUrl =
+    matched.backgroundImage && urlRegex.test(matched.backgroundImage)
+      ? matched.backgroundImage
+      : undefined;
+
+  const result: IdmThemeResult = {
+    theme: toIdmTheme(matched),
+    backgroundImageUrl,
+  };
+
+  themeCache.set(cacheKey, result);
+  return result;
+}

--- a/apps/login-app/src/routes/(app)/+layout.server.ts
+++ b/apps/login-app/src/routes/(app)/+layout.server.ts
@@ -10,15 +10,17 @@
 import { error } from '@sveltejs/kit';
 
 import { env } from '$env/dynamic/private';
+import { fetchIdmTheme } from '$server/idm-theme.effects';
 
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = () => {
+export const load: LayoutServerLoad = async ({ url }) => {
   const amUrl = env.FR_AM_URL;
   const clientId = env.FR_OAUTH_PUBLIC_CLIENT;
   const realmPath = env.FR_REALM_PATH;
   const wellknown = env.FR_AM_WELLKNOWN_URL;
   const scope = env.FR_OAUTH_SCOPE;
+  const idmBaseUrl = env.FR_IDM_URL ?? amUrl;
 
   if (!amUrl || !realmPath || !wellknown) {
     throw error(
@@ -27,9 +29,16 @@ export const load: LayoutServerLoad = () => {
     );
   }
 
+  const journeyName = url.searchParams.get('journey') ?? env.FR_AM_JOURNEY_LOGIN ?? null;
+  const { theme: idmTheme, backgroundImageUrl } = idmBaseUrl
+    ? await fetchIdmTheme(idmBaseUrl, realmPath, journeyName)
+    : { theme: undefined, backgroundImageUrl: undefined };
+
   return {
     amUrl,
+    backgroundImageUrl,
     clientId,
+    idmTheme,
     realmPath,
     scope,
     wellknown,

--- a/apps/login-app/src/routes/(app)/+layout.svelte
+++ b/apps/login-app/src/routes/(app)/+layout.svelte
@@ -1,11 +1,28 @@
 <!--
- 
+
  Copyright © 2025 - 2026 Ping Identity Corporation. All right reserved.
- 
+
  This software may be modified and distributed under the terms
  of the MIT license. See the LICENSE file for details.
- 
+
  -->
+
+<script lang="ts">
+  import { buildThemeVarsEntries } from '$core/_utilities/theme.utilities';
+
+  import type { ThemeObject } from '$core/style.store';
+
+  export let data: { idmTheme?: ThemeObject; backgroundImageUrl?: string };
+
+  $: themeStyle = [
+    ...(data.idmTheme ? buildThemeVarsEntries(data.idmTheme) : []),
+    ...(data.backgroundImageUrl
+      ? [['--fr-page-bg-image', `url("${data.backgroundImageUrl}")`] as [string, string]]
+      : []),
+  ]
+    .map(([k, v]) => `${k}:${v}`)
+    .join(';');
+</script>
 
 <svelte:head>
   <!--
@@ -21,7 +38,7 @@
 
   <meta charset="utf-8" />
   <title>Login Application</title>
-  <link rel="icon" href="/favicon.ico" />
+  <link rel="icon" href={data.idmTheme?.favicon ?? '/favicon.ico'} />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     /**
@@ -68,6 +85,9 @@
     .root {
       height: 100%;
       min-height: 100%;
+    }
+
+    html {
       background-color: #f6f8fa;
     }
 
@@ -84,4 +104,12 @@
   </style>
 </svelte:head>
 
-<slot />
+<div class="theme-root" style={themeStyle}>
+  <slot />
+</div>
+
+<style>
+  .theme-root {
+    height: 100%;
+  }
+</style>

--- a/apps/login-app/src/routes/(app)/+layout.ts
+++ b/apps/login-app/src/routes/(app)/+layout.ts
@@ -11,6 +11,7 @@ import '../../app.css';
 import { browser } from '$app/environment';
 import { initialize as initializeLinks } from '$core/links.store';
 import configure from '$core/sdk.config';
+import { initialize as initializeStyles } from '$core/style.store';
 import { initialize as initializeJourneys } from '$journey/config.store';
 
 import type { LayoutLoad } from './$types';
@@ -30,6 +31,19 @@ export const load: LayoutLoad = ({ data }) => {
   initializeLinks({
     termsAndConditions: 'https://www.forgerock.com/terms',
   });
+
+  if (data.idmTheme) {
+    initializeStyles({
+      theme: data.idmTheme,
+      ...(data.idmTheme.logo && {
+        logo: {
+          light: data.idmTheme.logo,
+          dark: data.idmTheme.logo,
+          ...(data.idmTheme.logoHeight && { height: data.idmTheme.logoHeight }),
+        },
+      }),
+    });
+  }
 
   return data;
 };

--- a/apps/login-app/src/routes/e2e/widget/inline/theme/+page.svelte
+++ b/apps/login-app/src/routes/e2e/widget/inline/theme/+page.svelte
@@ -1,0 +1,61 @@
+<!--
+
+ Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
+
+ This software may be modified and distributed under the terms
+ of the MIT license. See the LICENSE file for details.
+
+ -->
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  import { page } from '$app/stores';
+  import Widget, { configuration, journey } from '$package/index';
+
+  let formEl: HTMLDivElement;
+
+  onMount(() => {
+    const params = $page.url.searchParams;
+    const primaryColorParam = params.get('primaryColor');
+    const buttonBorderRadiusParam = params.get('buttonBorderRadius');
+    const cardBorderRadiusParam = params.get('cardBorderRadius');
+
+    configuration({
+      journeyClient: {
+        serverConfig: {
+          wellknown:
+            'https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration',
+        },
+      },
+      forgerock: {
+        clientId: 'WebOAuthClient',
+        redirectUri: `${window.location.origin}/callback`,
+        scope: 'openid profile email me.read',
+        serverConfig: {
+          baseUrl: 'https://openam-sdks.forgeblocks.com/am/',
+          timeout: 5000,
+        },
+        realmPath: 'alpha',
+      },
+      style: {
+        theme: {
+          ...(primaryColorParam !== null ? { primaryColor: primaryColorParam } : {}),
+          ...(buttonBorderRadiusParam !== null
+            ? { buttonBorderRadius: Number(buttonBorderRadiusParam) }
+            : {}),
+          ...(cardBorderRadiusParam !== null
+            ? { cardBorderRadius: Number(cardBorderRadiusParam) }
+            : {}),
+        },
+      },
+    });
+
+    const journeyEvents = journey();
+
+    new Widget({ target: formEl, props: { type: 'inline' } });
+    journeyEvents.start({ journey: 'TEST_Login' });
+  });
+</script>
+
+<div bind:this={formEl} class="tw_p-6"></div>

--- a/apps/login-app/src/routes/e2e/widget/modal/theme/+page.svelte
+++ b/apps/login-app/src/routes/e2e/widget/modal/theme/+page.svelte
@@ -1,0 +1,73 @@
+<!--
+
+ Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
+
+ This software may be modified and distributed under the terms
+ of the MIT license. See the LICENSE file for details.
+
+ -->
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  import { page } from '$app/stores';
+  import Widget, { component, configuration, journey } from '$package/index';
+
+  let componentEvents: ReturnType<typeof component> | undefined;
+  let journeyEvents: ReturnType<typeof journey> | undefined;
+  let widgetEl: HTMLDivElement;
+
+  onMount(() => {
+    const params = $page.url.searchParams;
+    const primaryColorParam = params.get('primaryColor');
+    const buttonBorderRadiusParam = params.get('buttonBorderRadius');
+    const cardBorderRadiusParam = params.get('cardBorderRadius');
+
+    configuration({
+      journeyClient: {
+        serverConfig: {
+          wellknown:
+            'https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration',
+        },
+      },
+      forgerock: {
+        clientId: 'WebOAuthClient',
+        redirectUri: `${window.location.origin}/callback`,
+        scope: 'openid profile email me.read',
+        serverConfig: {
+          baseUrl: 'https://openam-sdks.forgeblocks.com/am/',
+          timeout: 5000,
+        },
+        realmPath: 'alpha',
+      },
+      style: {
+        theme: {
+          ...(primaryColorParam !== null ? { primaryColor: primaryColorParam } : {}),
+          ...(buttonBorderRadiusParam !== null
+            ? { buttonBorderRadius: Number(buttonBorderRadiusParam) }
+            : {}),
+          ...(cardBorderRadiusParam !== null
+            ? { cardBorderRadius: Number(cardBorderRadiusParam) }
+            : {}),
+        },
+      },
+    });
+
+    componentEvents = component();
+    journeyEvents = journey();
+
+    new Widget({ target: widgetEl });
+  });
+</script>
+
+<div class="tw_p-6">
+  <button
+    on:click={() => {
+      journeyEvents?.start({ journey: 'TEST_Login' });
+      componentEvents?.open();
+    }}
+  >
+    Open Login Modal
+  </button>
+</div>
+<div bind:this={widgetEl}></div>

--- a/core/_effects/theme.effects.test.ts
+++ b/core/_effects/theme.effects.test.ts
@@ -1,0 +1,217 @@
+/**
+ *
+ * Copyright © 2025 - 2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { describe, expect, it } from 'vitest';
+
+import { applyThemeVars } from '$core/_effects/theme.effects';
+
+describe('applyThemeVars', () => {
+  const makeEl = (): HTMLElement => {
+    const props: Record<string, string> = {};
+    return {
+      style: {
+        setProperty: (name: string, value: string) => {
+          props[name] = value;
+        },
+        getPropertyValue: (name: string) => props[name] ?? '',
+        get length() {
+          return Object.keys(props).length;
+        },
+      },
+    } as unknown as HTMLElement;
+  };
+
+  it('is a noop when rootEl is null', () => {
+    expect(() => applyThemeVars(null, { primaryColor: '#334155' })).not.toThrow();
+  });
+
+  it('is a noop when theme is undefined', () => {
+    const el = makeEl();
+    applyThemeVars(el, undefined);
+    expect(el.style.length).toBe(0);
+  });
+
+  it('sets primary color HSL slots on both light and dark vars', () => {
+    const el = makeEl();
+    applyThemeVars(el, { primaryColor: '#334155' });
+    expect(el.style.getPropertyValue('--tw-colors-primary-dark-hs')).toBe('215.3, 25%');
+    expect(el.style.getPropertyValue('--tw-colors-primary-dark-l')).toBe('26.7%');
+    expect(el.style.getPropertyValue('--tw-colors-primary-light-hs')).toBe('215.3, 25%');
+    expect(el.style.getPropertyValue('--tw-colors-primary-light-l')).toBe('26.7%');
+  });
+
+  it('sets primaryOffColor on its own independent slot', () => {
+    const el = makeEl();
+    applyThemeVars(el, { primaryOffColor: '#374151' });
+    expect(el.style.getPropertyValue('--tw-colors-primary-off-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--tw-colors-primary-off-l')).toBeTruthy();
+  });
+
+  it('sets backgroundColor on both light and dark slots and --fr-page-bg-color', () => {
+    const el = makeEl();
+    applyThemeVars(el, { backgroundColor: '#f6f8fa' });
+    expect(el.style.getPropertyValue('--tw-colors-background-light-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--tw-colors-background-dark-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--fr-page-bg-color')).toBe('#f6f8fa');
+  });
+
+  it('sets linkColor on link-dark slot only', () => {
+    const el = makeEl();
+    applyThemeVars(el, { linkColor: '#2563eb' });
+    expect(el.style.getPropertyValue('--tw-colors-link-dark-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--tw-colors-link-light-hs')).toBe('');
+  });
+
+  it('sets buttonBorderRadius as px value on --fr-button-border-radius', () => {
+    const el = makeEl();
+    applyThemeVars(el, { buttonBorderRadius: 5 });
+    expect(el.style.getPropertyValue('--fr-button-border-radius')).toBe('5px');
+  });
+
+  it('sets fontFamily on --fr-font-family', () => {
+    const el = makeEl();
+    applyThemeVars(el, { fontFamily: 'Inter' });
+    expect(el.style.getPropertyValue('--fr-font-family')).toBe('Inter');
+  });
+
+  it('sets cardBorderRadius as px value', () => {
+    const el = makeEl();
+    applyThemeVars(el, { cardBorderRadius: 8 });
+    expect(el.style.getPropertyValue('--fr-card-border-radius')).toBe('8px');
+  });
+
+  it('sets logo on --logo-light and --logo-dark', () => {
+    const el = makeEl();
+    applyThemeVars(el, { logo: 'https://example.com/logo.png' });
+    expect(el.style.getPropertyValue('--logo-light')).toBe('url("https://example.com/logo.png")');
+    expect(el.style.getPropertyValue('--logo-dark')).toBe('url("https://example.com/logo.png")');
+  });
+
+  it('percent-encodes double-quotes in logo URL', () => {
+    const el = makeEl();
+    applyThemeVars(el, { logo: 'https://example.com/logo.png%22onload=alert(1)' });
+    const value = el.style.getPropertyValue('--logo-light');
+    expect(value).not.toContain('"onload');
+    expect(value).toContain('%22');
+  });
+
+  it('sets linkActiveColor on link-light slot only', () => {
+    const el = makeEl();
+    applyThemeVars(el, { linkActiveColor: '#60a5fa' });
+    expect(el.style.getPropertyValue('--tw-colors-link-light-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--tw-colors-link-dark-hs')).toBe('');
+  });
+
+  it('sets inputTextColor as HSL compound var', () => {
+    const el = makeEl();
+    applyThemeVars(el, { inputTextColor: '#111827' });
+    expect(el.style.getPropertyValue('--fr-input-text-color-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--fr-input-text-color-l')).toBeTruthy();
+    expect(el.style.getPropertyValue('--fr-input-text-color')).toMatch(/^hsl\(/);
+  });
+
+  it('sets cardTextColor as HSL compound var', () => {
+    const el = makeEl();
+    applyThemeVars(el, { cardTextColor: '#1f2937' });
+    expect(el.style.getPropertyValue('--fr-card-text-color-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--fr-card-text-color')).toMatch(/^hsl\(/);
+  });
+
+  it('sets bodyTextColor as HSL compound var', () => {
+    const el = makeEl();
+    applyThemeVars(el, { bodyTextColor: '#374151' });
+    expect(el.style.getPropertyValue('--fr-body-text-color-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--fr-body-text-color')).toMatch(/^hsl\(/);
+  });
+
+  it('sets buttonTextColor as HSL compound var on button text slot', () => {
+    const el = makeEl();
+    applyThemeVars(el, { buttonTextColor: '#ffffff' });
+    expect(el.style.getPropertyValue('--fr-button-text-color-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--fr-button-text-color')).toMatch(/^hsl\(/);
+  });
+
+  it('sets primaryOffColor on independent primary-off slot', () => {
+    const el = makeEl();
+    applyThemeVars(el, { primaryOffColor: '#374151' });
+    expect(el.style.getPropertyValue('--tw-colors-primary-off-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--tw-colors-primary-off-l')).toBeTruthy();
+    // Must NOT set primary-dark slot
+    expect(el.style.getPropertyValue('--tw-colors-primary-dark-hs')).toBe('');
+  });
+
+  it('sets inputBgColor directly on --fr-input-bg-color', () => {
+    const el = makeEl();
+    applyThemeVars(el, { inputBgColor: '#ffffff' });
+    expect(el.style.getPropertyValue('--fr-input-bg-color')).toBe('#ffffff');
+  });
+
+  it('sets inputFocusRingColor on --fr-focus-ring-color only, not the shared focus-default slots', () => {
+    const el = makeEl();
+    applyThemeVars(el, { inputFocusRingColor: '#D80000' });
+    expect(el.style.getPropertyValue('--fr-focus-ring-color')).toMatch(/^hsl\(/);
+    // Must NOT touch --tw-colors-focus-default-* (shared by all focusable elements)
+    expect(el.style.getPropertyValue('--tw-colors-focus-default-hs')).toBe('');
+    expect(el.style.getPropertyValue('--tw-colors-focus-default-l')).toBe('');
+  });
+
+  it('sets buttonFocusRingColor on --fr-button-focus-ring-color as hsl()', () => {
+    const el = makeEl();
+    applyThemeVars(el, { buttonFocusRingColor: '#0672cb' });
+    expect(el.style.getPropertyValue('--fr-button-focus-ring-color')).toMatch(/^hsl\(/);
+  });
+
+  it('sets inputLabelColor directly on --fr-input-label-color', () => {
+    const el = makeEl();
+    applyThemeVars(el, { inputLabelColor: '#FFFFFF' });
+    expect(el.style.getPropertyValue('--fr-input-label-color')).toBe('#FFFFFF');
+  });
+
+  it('sets selectAccentColor directly on --fr-select-accent-color', () => {
+    const el = makeEl();
+    applyThemeVars(el, { selectAccentColor: '#0672CB' });
+    expect(el.style.getPropertyValue('--fr-select-accent-color')).toBe('#0672CB');
+  });
+
+  it('sets selectHoverBgColor directly on --fr-select-hover-bg-color', () => {
+    const el = makeEl();
+    applyThemeVars(el, { selectHoverBgColor: '#e8f0fe' });
+    expect(el.style.getPropertyValue('--fr-select-hover-bg-color')).toBe('#e8f0fe');
+  });
+
+  it('sets inputBorderColor on --fr-input-border (shorthand) and --fr-input-border-color-value', () => {
+    const el = makeEl();
+    applyThemeVars(el, { inputBorderColor: '#D200FF' });
+    expect(el.style.getPropertyValue('--fr-input-border')).toBe('1px solid #D200FF');
+    expect(el.style.getPropertyValue('--fr-input-border-color-value')).toBe('#D200FF');
+  });
+
+  it('sets cardBgColor directly on --fr-card-bg-color', () => {
+    const el = makeEl();
+    applyThemeVars(el, { cardBgColor: '#111217' });
+    expect(el.style.getPropertyValue('--fr-card-bg-color')).toBe('#111217');
+  });
+
+  it('sets secondaryColor on all three secondary HSL slot pairs', () => {
+    const el = makeEl();
+    applyThemeVars(el, { secondaryColor: '#3A7BD5' });
+    expect(el.style.getPropertyValue('--tw-colors-secondary-dark-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--tw-colors-secondary-dark-l')).toBeTruthy();
+    expect(el.style.getPropertyValue('--tw-colors-secondary-default-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--tw-colors-secondary-default-l')).toBeTruthy();
+    expect(el.style.getPropertyValue('--tw-colors-secondary-light-hs')).toBeTruthy();
+    expect(el.style.getPropertyValue('--tw-colors-secondary-light-l')).toBeTruthy();
+  });
+
+  it('silently skips invalid hex values without throwing', () => {
+    const el = makeEl();
+    expect(() => applyThemeVars(el, { primaryColor: 'not-a-hex' as never })).not.toThrow();
+    expect(el.style.getPropertyValue('--tw-colors-primary-dark-hs')).toBe('');
+  });
+});

--- a/core/_effects/theme.effects.ts
+++ b/core/_effects/theme.effects.ts
@@ -1,0 +1,23 @@
+/**
+ *
+ * Copyright © 2025 - 2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { buildThemeVarsEntries } from '$core/_utilities/theme.utilities';
+
+import type { ThemeObject } from '$core/style.store';
+
+/**
+ * Applies IDM theme values as CSS custom properties on a root element.
+ * Noop when `theme` is undefined or the element reference is null.
+ */
+export function applyThemeVars(rootEl: HTMLElement | null, theme: ThemeObject | undefined): void {
+  if (!rootEl || !theme) return;
+  for (const [name, value] of buildThemeVarsEntries(theme)) {
+    rootEl.style.setProperty(name, value);
+  }
+}

--- a/core/_utilities/theme.utilities.test.ts
+++ b/core/_utilities/theme.utilities.test.ts
@@ -1,0 +1,128 @@
+/**
+ *
+ * Copyright © 2025 - 2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { describe, expect, it } from 'vitest';
+
+import { buildThemeVarsEntries, encodeCssUrl, hexToHslChannels } from './theme.utilities';
+
+describe('encodeCssUrl', () => {
+  it('wraps a plain URL in url("…")', () => {
+    expect(encodeCssUrl('https://example.com/logo.png')).toBe(
+      'url("https://example.com/logo.png")',
+    );
+  });
+
+  it('percent-encodes double-quotes to prevent breaking out of the quoted url()', () => {
+    const result = encodeCssUrl('https://x.test/a.png");background:url("https://evil.test/x.png');
+    expect(result).not.toContain('");background');
+    expect(result).toContain('%22');
+    // The whole value stays inside a single quoted url("…") token.
+    expect(result.startsWith('url("')).toBe(true);
+    expect(result.endsWith('")')).toBe(true);
+  });
+
+  it('encodes every double-quote, not just the first', () => {
+    expect(encodeCssUrl('a"b"c')).toBe('url("a%22b%22c")');
+  });
+});
+
+describe('buildThemeVarsEntries', () => {
+  it('returns empty array for empty theme', () => {
+    expect(buildThemeVarsEntries({})).toEqual([]);
+  });
+
+  it('returns both light and dark primary HSL entries from primaryColor', () => {
+    const entries = buildThemeVarsEntries({ primaryColor: '#ff0000' });
+    expect(entries).toContainEqual(['--tw-colors-primary-dark-hs', '0, 100%']);
+    expect(entries).toContainEqual(['--tw-colors-primary-light-hs', '0, 100%']);
+    expect(entries).toContainEqual(['--tw-colors-primary-dark-l', '50%']);
+    expect(entries).toContainEqual(['--tw-colors-primary-light-l', '50%']);
+  });
+
+  it('returns --fr-button-border-radius from buttonBorderRadius', () => {
+    const entries = buildThemeVarsEntries({ buttonBorderRadius: 8 });
+    expect(entries).toContainEqual(['--fr-button-border-radius', '8px']);
+  });
+
+  it('returns --fr-input-bg-color from inputBgColor', () => {
+    const entries = buildThemeVarsEntries({ inputBgColor: '#ffffff' });
+    expect(entries).toContainEqual(['--fr-input-bg-color', '#ffffff']);
+  });
+
+  it('returns logo vars using encodeCssUrl', () => {
+    const entries = buildThemeVarsEntries({ logo: 'https://example.com/logo.png' });
+    expect(entries).toContainEqual(['--logo-light', 'url("https://example.com/logo.png")']);
+    expect(entries).toContainEqual(['--logo-dark', 'url("https://example.com/logo.png")']);
+  });
+
+  it('silently skips invalid hex fields', () => {
+    const entries = buildThemeVarsEntries({ primaryColor: undefined });
+    expect(entries).toEqual([]);
+  });
+
+  it('returns all three secondary slot pairs from secondaryColor', () => {
+    const entries = buildThemeVarsEntries({ secondaryColor: '#0000ff' });
+    const names = entries.map(([name]) => name);
+    expect(names).toContain('--tw-colors-secondary-dark-hs');
+    expect(names).toContain('--tw-colors-secondary-default-hs');
+    expect(names).toContain('--tw-colors-secondary-light-hs');
+  });
+});
+
+describe('hexToHslChannels', () => {
+  it('converts 6-digit hex with # prefix', () => {
+    const result = hexToHslChannels('#334155');
+    expect(result.hs).toMatch(/^\d+\.?\d*, \d+\.?\d*%$/);
+    expect(result.l).toMatch(/^\d+\.?\d*%$/);
+  });
+
+  it('converts 6-digit hex without # prefix', () => {
+    const result = hexToHslChannels('334155');
+    expect(result.hs).toBe('215.3, 25%');
+    expect(result.l).toBe('26.7%');
+  });
+
+  it('handles pure black', () => {
+    const result = hexToHslChannels('#000000');
+    expect(result.hs).toBe('0, 0%');
+    expect(result.l).toBe('0%');
+  });
+
+  it('handles pure white', () => {
+    const result = hexToHslChannels('#ffffff');
+    expect(result.hs).toBe('0, 0%');
+    expect(result.l).toBe('100%');
+  });
+
+  it('handles a saturated red', () => {
+    const result = hexToHslChannels('#ff0000');
+    expect(result.hs).toBe('0, 100%');
+    expect(result.l).toBe('50%');
+  });
+
+  it('accepts 8-digit hex by stripping alpha channel', () => {
+    const result = hexToHslChannels('#E00202BD');
+    expect(result.hs).toBe('0, 98.2%');
+    expect(result.l).toBe('44.3%');
+  });
+
+  it('accepts 8-digit hex without # prefix by stripping alpha', () => {
+    const result8 = hexToHslChannels('FF0000FF');
+    const result6 = hexToHslChannels('FF0000');
+    expect(result8.hs).toBe(result6.hs);
+    expect(result8.l).toBe(result6.l);
+  });
+
+  it('throws on invalid hex', () => {
+    expect(() => hexToHslChannels('#xyz')).toThrow('Invalid hex color');
+    expect(() => hexToHslChannels('not-a-color')).toThrow('Invalid hex color');
+    expect(() => hexToHslChannels('#12345')).toThrow('Invalid hex color');
+    expect(() => hexToHslChannels('#fff')).toThrow('Invalid hex color');
+  });
+});

--- a/core/_utilities/theme.utilities.ts
+++ b/core/_utilities/theme.utilities.ts
@@ -1,0 +1,208 @@
+/**
+ *
+ * Copyright © 2025 - 2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import type { ThemeObject } from '$core/style.store';
+
+/**
+ * Builds a safe CSS `url("…")` value from an untrusted URL string.
+ *
+ * The widget injects consumer- and IDM-supplied logo URLs into inline `style`
+ * attributes as `url("<value>")`. A raw `"` in the value would close the quoted
+ * string early and let an attacker append arbitrary CSS declarations. We
+ * percent-encode the only character that can break out of the quoted form (`"`),
+ * which a URL never needs literally. Returns the full `url("…")` token ready to
+ * drop into a declaration.
+ */
+export function encodeCssUrl(url: string): string {
+  return `url("${url.replace(/"/g, '%22')}")`;
+}
+
+/**
+ * Converts a CSS hex color string to HSL channel pair strings matching the
+ * --tw-colors-*-hs / --tw-colors-*-l slot format used in compiled component classes.
+ *
+ * Returns `{ hs: "H, S%", l: "L%" }` — the two values are kept separate because
+ * component classes reference them independently (e.g. `calc(var(--tw-colors-*-l) - 10%)`).
+ *
+ * Accepts 6-digit hex strings (#RRGGBB or RRGGBB). Throws on anything else.
+ */
+export function hexToHslChannels(hex: string): { hs: string; l: string } {
+  let normalized = hex.startsWith('#') ? hex.slice(1) : hex;
+
+  if (/^[0-9a-fA-F]{8}$/.test(normalized)) {
+    normalized = normalized.slice(0, 6);
+  }
+
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    throw new Error(`Invalid hex color: "${hex}"`);
+  }
+
+  const red = parseInt(normalized.slice(0, 2), 16) / 255;
+  const green = parseInt(normalized.slice(2, 4), 16) / 255;
+  const blue = parseInt(normalized.slice(4, 6), 16) / 255;
+
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  const delta = max - min;
+
+  const lightness = (max + min) / 2;
+
+  let hue = 0;
+  if (delta !== 0) {
+    if (max === red) {
+      hue = ((green - blue) / delta) % 6;
+    } else if (max === green) {
+      hue = (blue - red) / delta + 2;
+    } else {
+      hue = (red - green) / delta + 4;
+    }
+    hue = Math.round(hue * 600) / 10;
+    if (hue < 0) hue += 360;
+  }
+
+  const saturation =
+    delta === 0 ? 0 : Math.round((delta / (1 - Math.abs(2 * lightness - 1))) * 1000) / 10;
+
+  const lightnessPercent = Math.round(lightness * 1000) / 10;
+
+  return {
+    hs: `${hue}, ${saturation}%`,
+    l: `${lightnessPercent}%`,
+  };
+}
+
+/**
+ * Maps an IDM theme object to a flat list of CSS custom property name/value
+ * pairs. Invalid or missing fields are silently omitted.
+ */
+export function buildThemeVarsEntries(theme: ThemeObject): [string, string][] {
+  const entries: [string, string][] = [];
+
+  const cssVar = (name: string, value: string): void => {
+    entries.push([name, value]);
+  };
+
+  const hslPair = (hsVar: string, lVar: string, hex: string): void => {
+    try {
+      const { hs, l } = hexToHslChannels(hex);
+      entries.push([hsVar, hs], [lVar, l]);
+    } catch {
+      // invalid hex — skip
+    }
+  };
+
+  const hslCompound = (varName: string, hex: string): void => {
+    try {
+      const { hs, l } = hexToHslChannels(hex);
+      cssVar(varName, `hsl(${hs}, ${l})`);
+    } catch {
+      // invalid hex — skip
+    }
+  };
+
+  const hslSlotWithCompound = (baseName: string, hex: string): void => {
+    try {
+      const { hs, l } = hexToHslChannels(hex);
+      cssVar(`${baseName}-hs`, hs);
+      cssVar(`${baseName}-l`, l);
+      cssVar(baseName, `hsl(var(${baseName}-hs), var(${baseName}-l))`);
+    } catch {
+      // invalid hex — skip
+    }
+  };
+
+  if (theme.primaryColor) {
+    hslPair('--tw-colors-primary-dark-hs', '--tw-colors-primary-dark-l', theme.primaryColor);
+    hslPair('--tw-colors-primary-light-hs', '--tw-colors-primary-light-l', theme.primaryColor);
+  }
+  if (theme.primaryOffColor) {
+    hslPair('--tw-colors-primary-off-hs', '--tw-colors-primary-off-l', theme.primaryOffColor);
+  }
+  if (theme.secondaryColor) {
+    hslPair('--tw-colors-secondary-dark-hs', '--tw-colors-secondary-dark-l', theme.secondaryColor);
+    hslPair(
+      '--tw-colors-secondary-default-hs',
+      '--tw-colors-secondary-default-l',
+      theme.secondaryColor,
+    );
+    hslPair(
+      '--tw-colors-secondary-light-hs',
+      '--tw-colors-secondary-light-l',
+      theme.secondaryColor,
+    );
+  }
+  if (theme.backgroundColor) {
+    hslPair(
+      '--tw-colors-background-dark-hs',
+      '--tw-colors-background-dark-l',
+      theme.backgroundColor,
+    );
+    hslPair(
+      '--tw-colors-background-light-hs',
+      '--tw-colors-background-light-l',
+      theme.backgroundColor,
+    );
+    cssVar('--fr-page-bg-color', theme.backgroundColor);
+  }
+  if (theme.linkColor) {
+    hslPair('--tw-colors-link-dark-hs', '--tw-colors-link-dark-l', theme.linkColor);
+  }
+  if (theme.linkActiveColor) {
+    hslPair('--tw-colors-link-light-hs', '--tw-colors-link-light-l', theme.linkActiveColor);
+  }
+  if (theme.fontFamily) {
+    cssVar('--fr-font-family', theme.fontFamily);
+  }
+  if (theme.buttonBorderRadius !== undefined) {
+    cssVar('--fr-button-border-radius', `${theme.buttonBorderRadius}px`);
+  }
+  if (theme.cardBorderRadius !== undefined) {
+    cssVar('--fr-card-border-radius', `${theme.cardBorderRadius}px`);
+  }
+  if (theme.cardBgColor) {
+    cssVar('--fr-card-bg-color', theme.cardBgColor);
+  }
+  if (theme.inputBgColor) {
+    cssVar('--fr-input-bg-color', theme.inputBgColor);
+  }
+  if (theme.inputBorderColor) {
+    cssVar('--fr-input-border', `1px solid ${theme.inputBorderColor}`);
+    cssVar('--fr-input-border-color-value', theme.inputBorderColor);
+  }
+  if (theme.inputLabelColor) {
+    cssVar('--fr-input-label-color', theme.inputLabelColor);
+  }
+  if (theme.selectAccentColor) {
+    cssVar('--fr-select-accent-color', theme.selectAccentColor);
+  }
+  if (theme.selectHoverBgColor) {
+    cssVar('--fr-select-hover-bg-color', theme.selectHoverBgColor);
+  }
+  if (theme.inputFocusRingColor) {
+    // Only set --fr-focus-ring-color — do NOT touch --tw-colors-focus-default-*
+    // which is the shared global used by all focusable elements (buttons, links, etc.)
+    // as their at-rest outline-color transition start. Polluting it would cause all
+    // non-input elements to start their focus transition from the input color.
+    hslCompound('--fr-focus-ring-color', theme.inputFocusRingColor);
+  }
+  if (theme.buttonFocusRingColor) {
+    hslCompound('--fr-button-focus-ring-color', theme.buttonFocusRingColor);
+  }
+  if (theme.inputTextColor) hslSlotWithCompound('--fr-input-text-color', theme.inputTextColor);
+  if (theme.cardTextColor) hslSlotWithCompound('--fr-card-text-color', theme.cardTextColor);
+  if (theme.bodyTextColor) hslSlotWithCompound('--fr-body-text-color', theme.bodyTextColor);
+  if (theme.buttonTextColor) hslSlotWithCompound('--fr-button-text-color', theme.buttonTextColor);
+  if (theme.logo) {
+    const safeLogoUrl = encodeCssUrl(theme.logo);
+    cssVar('--logo-light', safeLogoUrl);
+    cssVar('--logo-dark', safeLogoUrl);
+  }
+
+  return entries;
+}

--- a/core/components/compositions/dialog/dialog.svelte
+++ b/core/components/compositions/dialog/dialog.svelte
@@ -9,6 +9,7 @@
 
 <script lang="ts">
   import T from '$components/_utilities/locale-strings.svelte';
+  import { encodeCssUrl } from '$core/_utilities/theme.utilities';
   import { closeComponent } from '$core/component.store';
   import { styleStore } from '$core/style.store';
   import XIcon from '../../icons/x-icon.svelte';
@@ -62,11 +63,11 @@
     <div class="tw_dialog-header dark:tw_dialog-header_dark">
       <div
         class="tw_dialog-logo dark:tw_dialog-logo_dark"
-        style={`--logo-dark: url("${$styleStore?.logo?.dark}"); --logo-light: url("${
-          $styleStore?.logo?.light
-        }"); ${$styleStore?.logo?.height ? `height: ${$styleStore?.logo.height}px;` : ''} ${
-          $styleStore?.logo?.width ? `width: ${$styleStore?.logo.width}px;` : ''
-        }`}
+        style={`--logo-dark: ${encodeCssUrl(
+          $styleStore?.logo?.dark ?? '',
+        )}; --logo-light: ${encodeCssUrl($styleStore?.logo?.light ?? '')}; ${
+          $styleStore?.logo?.height ? `height: ${$styleStore?.logo.height}px;` : ''
+        } ${$styleStore?.logo?.width ? `width: ${$styleStore?.logo.width}px;` : ''}`}
       ></div>
       <button
         class="tw_dialog-x md:tw_dialog-x_medium tw_focusable-element dark:tw_focusable-element_dark"
@@ -99,7 +100,9 @@
       {#if $styleStore?.logo}
         <div
           class="tw_dialog-logo dark:tw_dialog-logo_dark"
-          style={`--logo-dark: url("${$styleStore?.logo?.dark}"); --logo-light: url("${$styleStore?.logo?.light}")`}
+          style={`--logo-dark: ${encodeCssUrl(
+            $styleStore?.logo?.dark ?? '',
+          )}; --logo-light: ${encodeCssUrl($styleStore?.logo?.light ?? '')}`}
         ></div>
       {/if}
     </div>

--- a/core/components/primitives/box/centered.svelte
+++ b/core/components/primitives/box/centered.svelte
@@ -1,6 +1,6 @@
 <!--
 
- Copyright © 2025 Ping Identity Corporation. All right reserved.
+ Copyright © 2025 - 2026 Ping Identity Corporation. All right reserved.
 
  This software may be modified and distributed under the terms
  of the MIT license. See the LICENSE file for details.
@@ -11,8 +11,38 @@
   // Component with slot only - no props needed
 </script>
 
-<div class="tw_bg-body-light dark:tw_bg-body-dark tw_flex tw_justify-center tw_min-h-full">
+<div class="page-shell tw_flex tw_justify-center tw_min-h-full">
   <div class="tw_containing-box dark:tw_containing-box_dark md:tw_containing-box_medium">
     <slot />
   </div>
 </div>
+
+<style>
+  .page-shell {
+    background-color: var(
+      --fr-page-bg-color,
+      hsl(var(--tw-colors-body-light-hs), var(--tw-colors-body-light-l))
+    );
+    background-image: var(--fr-page-bg-image, none);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    font-family: var(--fr-font-family, 'Open Sans'), ui-sans-serif, system-ui, sans-serif;
+  }
+
+  :global(.dark) .page-shell {
+    background-color: var(
+      --fr-page-bg-color,
+      hsl(var(--tw-colors-body-dark-hs), var(--tw-colors-body-dark-l))
+    );
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .page-shell {
+      background-color: var(
+        --fr-page-bg-color,
+        hsl(var(--tw-colors-body-dark-hs), var(--tw-colors-body-dark-l))
+      );
+    }
+  }
+</style>

--- a/core/journey/stages/generic.svelte
+++ b/core/journey/stages/generic.svelte
@@ -19,6 +19,7 @@
   import Form from '$components/primitives/form/form.svelte';
   // i18n
   import { interpolate } from '$core/_utilities/i18n.utilities';
+  import { encodeCssUrl } from '$core/_utilities/theme.utilities';
   import { styleStore } from '$core/style.store';
   import CallbackMapper from '$journey/_utilities/callback-mapper.svelte';
   import {
@@ -106,7 +107,18 @@
   needsFocus={formNeedsFocus}
   onSubmitWhenValid={submitFormWrapper}
 >
-  {#if form?.icon && componentStyle !== 'inline'}
+  {#if $styleStore?.logo && componentStyle !== 'modal'}
+    <div class="tw_flex tw_justify-center tw_pb-4">
+      <div
+        class="tw_dialog-logo dark:tw_dialog-logo_dark"
+        style={`--logo-light: ${encodeCssUrl(
+          $styleStore.logo.light ?? '',
+        )}; --logo-dark: ${encodeCssUrl($styleStore.logo.dark ?? '')}; height: ${
+          $styleStore.logo.height ? `${$styleStore.logo.height}px` : '72px'
+        }; width: ${$styleStore.logo.width ? `${$styleStore.logo.width}px` : '200px'};`}
+      ></div>
+    </div>
+  {:else if form?.icon && componentStyle !== 'inline'}
     <div class="tw_flex tw_justify-center">
       <ShieldIcon classes="tw_text-gray-400 tw_fill-current" size="72px" />
     </div>

--- a/core/journey/stages/login.svelte
+++ b/core/journey/stages/login.svelte
@@ -18,6 +18,7 @@
   import Form from '$components/primitives/form/form.svelte';
   // i18n
   import { interpolate } from '$core/_utilities/i18n.utilities';
+  import { encodeCssUrl } from '$core/_utilities/theme.utilities';
   import { styleStore } from '$core/style.store';
   import CallbackMapper from '$journey/_utilities/callback-mapper.svelte';
   import { convertStringToKey } from '$journey/stages/_utilities/step.utilities';
@@ -74,12 +75,23 @@
 </script>
 
 <Form bind:formEl ariaDescribedBy="formFailureMessageAlert" onSubmitWhenValid={form?.submit}>
+  {#if $styleStore?.logo && componentStyle !== 'modal'}
+    <div class="tw_flex tw_justify-center tw_pb-4">
+      <div
+        class="tw_dialog-logo dark:tw_dialog-logo_dark"
+        style={`--logo-light: ${encodeCssUrl(
+          $styleStore.logo.light ?? '',
+        )}; --logo-dark: ${encodeCssUrl($styleStore.logo.dark ?? '')}; height: ${
+          $styleStore.logo.height ? `${$styleStore.logo.height}px` : '72px'
+        }; width: ${$styleStore.logo.width ? `${$styleStore.logo.width}px` : '200px'};`}
+      ></div>
+    </div>
+  {:else if componentStyle !== 'inline' && form?.icon}
+    <div class="tw_flex tw_justify-center">
+      <KeyIcon classes="tw_text-gray-400 tw_fill-current" size="72px" />
+    </div>
+  {/if}
   {#if componentStyle !== 'inline'}
-    {#if form?.icon}
-      <div class="tw_flex tw_justify-center">
-        <KeyIcon classes="tw_text-gray-400 tw_fill-current" size="72px" />
-      </div>
-    {/if}
     <h1 class="tw_primary-header dark:tw_primary-header_dark">
       <T key="loginHeader" />
     </h1>

--- a/core/style.store.test.ts
+++ b/core/style.store.test.ts
@@ -1,0 +1,173 @@
+/**
+ *
+ * Copyright © 2025 - 2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { describe, expect, it } from 'vitest';
+
+import { initialize, styleSchema, themeSchema } from './style.store';
+
+import type { partialStyleSchema } from './style.store';
+
+describe('themeSchema', () => {
+  it('accepts valid 6-digit hex colors', () => {
+    const result = themeSchema.safeParse({ primaryColor: '#334155', backgroundColor: '#f6f8fa' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts all fields as optional — empty object is valid', () => {
+    expect(themeSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('drops 3-digit hex — parses but field is undefined', () => {
+    const result = themeSchema.safeParse({ primaryColor: '#fff' });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.primaryColor).toBeUndefined();
+  });
+
+  it('drops hex without # — parses but field is undefined', () => {
+    const result = themeSchema.safeParse({ primaryColor: '334155' });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.primaryColor).toBeUndefined();
+  });
+
+  it('drops non-hex string — parses but field is undefined', () => {
+    const result = themeSchema.safeParse({ primaryColor: 'red' });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.primaryColor).toBeUndefined();
+  });
+
+  it('rejects unknown keys (strict)', () => {
+    expect(themeSchema.safeParse({ unknownField: '#ffffff' }).success).toBe(false);
+  });
+
+  it('accepts https logo URL', () => {
+    expect(themeSchema.safeParse({ logo: 'https://example.com/logo.png' }).success).toBe(true);
+  });
+
+  it('accepts data:image logo URL', () => {
+    expect(themeSchema.safeParse({ logo: 'data:image/png;base64,abc123==' }).success).toBe(true);
+  });
+
+  it('drops logo with embedded double-quote — parses but logo is undefined', () => {
+    const result = themeSchema.safeParse({
+      logo: 'https://example.com/logo.png"onload=alert(1)',
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.logo).toBeUndefined();
+  });
+
+  it('drops javascript: logo URL — parses but logo is undefined', () => {
+    const result = themeSchema.safeParse({ logo: 'javascript:alert(1)' });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.logo).toBeUndefined();
+  });
+
+  it('accepts valid font family string', () => {
+    expect(themeSchema.safeParse({ fontFamily: "'Open Sans', sans-serif" }).success).toBe(true);
+  });
+
+  it('drops fontFamily with semicolon — parses but field is undefined', () => {
+    const result = themeSchema.safeParse({ fontFamily: 'Arial; color: red' });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.fontFamily).toBeUndefined();
+  });
+
+  it('drops fontFamily with brace — parses but field is undefined', () => {
+    const result = themeSchema.safeParse({ fontFamily: 'Arial } body { color: red' });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.fontFamily).toBeUndefined();
+  });
+
+  it('drops relative logo URL — other fields still parse correctly', () => {
+    const result = themeSchema.safeParse({
+      primaryColor: '#5AA625',
+      logo: 'img/placeholder.95d0bb8e.svg',
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.primaryColor).toBe('#5AA625');
+    expect(result.success && result.data.logo).toBeUndefined();
+  });
+
+  it('accepts numeric buttonBorderRadius', () => {
+    expect(themeSchema.safeParse({ buttonBorderRadius: 5 }).success).toBe(true);
+  });
+
+  it('rejects string buttonBorderRadius', () => {
+    expect(themeSchema.safeParse({ buttonBorderRadius: '5px' }).success).toBe(false);
+  });
+
+  it('accepts valid https favicon URL', () => {
+    const result = themeSchema.safeParse({ favicon: 'https://example.com/favicon.ico' });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.favicon).toBe('https://example.com/favicon.ico');
+  });
+
+  it('drops invalid favicon string (not URL) — parses but field is undefined', () => {
+    const result = themeSchema.safeParse({ favicon: 'not-a-url' });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.favicon).toBeUndefined();
+  });
+
+  it('accepts all Group D fields together', () => {
+    const result = themeSchema.safeParse({
+      primaryOffColor: '#374151',
+      fontFamily: 'Inter',
+      buttonBorderRadius: 8,
+      cardBorderRadius: 12,
+      inputTextColor: '#111827',
+      cardTextColor: '#1f2937',
+      bodyTextColor: '#374151',
+      buttonTextColor: '#ffffff',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('styleSchema — theme field', () => {
+  it('accepts styleSchema with valid theme', () => {
+    const result = styleSchema.safeParse({
+      theme: { primaryColor: '#027ab8' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts styleSchema without theme', () => {
+    expect(styleSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('drops invalid color field nested inside styleSchema — theme parsed with field undefined', () => {
+    const result = styleSchema.safeParse({ theme: { primaryColor: 'not-hex' } });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.theme?.primaryColor).toBeUndefined();
+  });
+});
+
+describe('initialize', () => {
+  it('merges theme into store when provided', () => {
+    const store = initialize({ theme: { primaryColor: '#027ab8' } });
+    let value: ReturnType<typeof partialStyleSchema.parse> | undefined;
+    store.subscribe((v) => (value = v))();
+    expect(value?.theme?.primaryColor).toBe('#027ab8');
+  });
+
+  it('resets to fallback when called with no argument', () => {
+    initialize({ theme: { primaryColor: '#027ab8' } });
+    const store = initialize();
+    let value: ReturnType<typeof partialStyleSchema.parse> | undefined;
+    store.subscribe((v) => (value = v))();
+    expect(value?.theme).toBeUndefined();
+  });
+
+  it('strips undefined theme — does not pollute store with undefined keys', () => {
+    const store = initialize({ checksAndRadios: 'standard' });
+    let value: ReturnType<typeof partialStyleSchema.parse> | undefined;
+    store.subscribe((v) => (value = v))();
+    expect(value?.checksAndRadios).toBe('standard');
+    expect(value?.theme).toBeUndefined();
+  });
+});

--- a/core/style.store.ts
+++ b/core/style.store.ts
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2025 Ping Identity Corporation. All right reserved.
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -11,6 +11,46 @@ import { writable } from 'svelte/store';
 import { z } from 'zod';
 
 import type { Writable } from 'svelte/store';
+
+const hexColorRegex = /^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/;
+
+export const urlRegex =
+  /^(https?:\/\/[^\s"'<>{}\\]+|data:image\/[a-zA-Z+]+;base64,[a-zA-Z0-9+/=]+)$/;
+
+const fontFamilyRegex = /^[a-zA-Z0-9\s,'\-."]+$/;
+
+const hexField = z.string().regex(hexColorRegex).optional().catch(undefined);
+
+export const themeSchema = z
+  .object({
+    primaryColor: hexField,
+    primaryOffColor: hexField,
+    secondaryColor: hexField,
+    backgroundColor: hexField,
+    linkColor: hexField,
+    linkActiveColor: hexField,
+    logo: z.string().regex(urlRegex).optional().catch(undefined),
+    favicon: z.string().regex(urlRegex).optional().catch(undefined),
+    logoHeight: z.number().optional(),
+    fontFamily: z.string().regex(fontFamilyRegex).optional().catch(undefined),
+    buttonBorderRadius: z.number().optional(),
+    cardBorderRadius: z.number().optional(),
+    cardBgColor: hexField,
+    inputBgColor: hexField,
+    inputBorderColor: hexField,
+    inputLabelColor: hexField,
+    inputFocusRingColor: hexField,
+    selectAccentColor: hexField,
+    selectHoverBgColor: hexField,
+    buttonFocusRingColor: hexField,
+    inputTextColor: hexField,
+    cardTextColor: hexField,
+    bodyTextColor: hexField,
+    buttonTextColor: hexField,
+  })
+  .strict();
+
+export type ThemeObject = z.infer<typeof themeSchema>;
 
 export const logoSchema = z
   .object({
@@ -41,6 +81,7 @@ export const styleSchema = z
       })
       .strict()
       .optional(),
+    theme: themeSchema.optional(),
   })
   .strict();
 
@@ -56,6 +97,7 @@ const fallbackStyles = {
   logo: undefined,
   sections: undefined,
   stage: undefined,
+  theme: undefined,
 } as const;
 
 export const styleStore: Writable<z.infer<typeof partialStyleSchema>> = writable(fallbackStyles);

--- a/core/style.stories.js
+++ b/core/style.stories.js
@@ -127,3 +127,29 @@ export const StandardChecksRadios = {
     },
   },
 };
+
+export const ThemeOverride = {
+  args: {
+    form: {
+      icon: true,
+      message: '',
+      status: '',
+      submit: fn(),
+    },
+    journey: {
+      loading: false,
+      pop: fn(),
+      push: fn(),
+      stack: writable([]),
+    },
+    stage: '',
+    step: frRegistrationStep,
+    style: {
+      theme: {
+        primaryColor: '#cc0000',
+        buttonRounded: 20,
+        journeyCardBorderRadius: 16,
+      },
+    },
+  },
+};

--- a/core/style.story.svelte
+++ b/core/style.story.svelte
@@ -9,6 +9,7 @@
 
 <script lang="ts">
   import Centered from '$components/primitives/box/centered.svelte';
+  import { applyThemeVars } from '$core/_effects/theme.effects';
   import { initialize as initializeLinks } from '$core/links.store';
   import { initialize as initializeStyles } from '$core/style.store';
   import { buildCallbackMetadata, buildStepMetadata } from '$journey/_utilities/metadata.utilities';
@@ -28,6 +29,7 @@
   export let step: JourneyStep;
   export let style: z.infer<typeof partialStyleSchema>;
 
+  let storyRootEl: HTMLElement | null = null;
   let stageName;
 
   // Mimic what happens in the `journey.store` module
@@ -55,9 +57,12 @@
 
   $: {
     initializeStyles(style);
+    applyThemeVars(storyRootEl, style?.theme);
   }
 </script>
 
-<Centered>
-  <Generic componentStyle="modal" {form} {journey} {metadata} {step} />
-</Centered>
+<div bind:this={storyRootEl} class="fr_widget-root">
+  <Centered>
+    <Generic componentStyle="modal" {form} {journey} {metadata} {step} />
+  </Centered>
+</div>

--- a/e2e/tests/widget/inline/widget-inline.theme.test.js
+++ b/e2e/tests/widget/inline/widget-inline.theme.test.js
@@ -1,0 +1,95 @@
+/**
+ *
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { expect, test } from '@playwright/test';
+
+test('Theme override applies CSS vars to inline widget root', async ({ page }) => {
+  await page.goto(
+    'widget/inline/theme?primaryColor=%23cc0000&buttonBorderRadius=20&cardBorderRadius=16',
+  );
+  await page.waitForSelector('.fr_widget-root', { state: 'attached' });
+
+  await test.step('primary color converts to HSL channel pair', async () => {
+    const primaryDarkHs = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--tw-colors-primary-dark-hs') ?? '';
+    });
+    const primaryDarkL = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--tw-colors-primary-dark-l') ?? '';
+    });
+    // #cc0000 = hsl(0, 100%, 40%)
+    expect(primaryDarkHs).toBe('0, 100%');
+    expect(primaryDarkL).toBe('40%');
+  });
+
+  await test.step('buttonBorderRadius sets --fr-button-border-radius', async () => {
+    const buttonRadius = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--fr-button-border-radius') ?? '';
+    });
+    expect(buttonRadius).toBe('20px');
+  });
+
+  await test.step('cardBorderRadius sets --fr-card-border-radius', async () => {
+    const cardRadius = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--fr-card-border-radius') ?? '';
+    });
+    expect(cardRadius).toBe('16px');
+  });
+});
+
+test('Default inline widget has no inline theme CSS vars', async ({ page }) => {
+  await page.goto('widget/inline/theme');
+  await page.waitForSelector('.fr_widget-root', { state: 'attached' });
+
+  await test.step('no --tw-colors-primary-dark-hs on root', async () => {
+    const primaryDarkHs = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--tw-colors-primary-dark-hs') ?? '';
+    });
+    expect(primaryDarkHs).toBe('');
+  });
+});
+
+test('Partial theme sets only the provided CSS vars on inline widget', async ({ page }) => {
+  await page.goto('widget/inline/theme?primaryColor=%23ff6600');
+  await page.waitForSelector('.fr_widget-root', { state: 'attached' });
+
+  await test.step('provided color is applied', async () => {
+    const primaryHs = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--tw-colors-primary-dark-hs') ?? '';
+    });
+    // #ff6600 = hsl(24, 100%, 50%)
+    expect(primaryHs).toBe('24, 100%');
+  });
+
+  await test.step('unset vars are absent', async () => {
+    const buttonRadius = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--fr-button-border-radius') ?? '';
+    });
+    expect(buttonRadius).toBe('');
+  });
+});
+
+test('Invalid hex color is ignored on inline widget', async ({ page }) => {
+  await page.goto('widget/inline/theme?primaryColor=notacolor');
+  await page.waitForSelector('.fr_widget-root', { state: 'attached' });
+
+  await test.step('invalid color produces no CSS var', async () => {
+    const primaryHs = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--tw-colors-primary-dark-hs') ?? '';
+    });
+    expect(primaryHs).toBe('');
+  });
+});

--- a/e2e/tests/widget/modal/widget-modal.theme.test.js
+++ b/e2e/tests/widget/modal/widget-modal.theme.test.js
@@ -1,0 +1,95 @@
+/**
+ *
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { expect, test } from '@playwright/test';
+
+test('Theme override applies CSS vars to widget root', async ({ page }) => {
+  await page.goto(
+    'widget/modal/theme?primaryColor=%23cc0000&buttonBorderRadius=20&cardBorderRadius=16',
+  );
+  await page.waitForSelector('.fr_widget-root', { state: 'attached' });
+
+  await test.step('primary color converts to HSL channel pair', async () => {
+    const primaryDarkHs = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--tw-colors-primary-dark-hs') ?? '';
+    });
+    const primaryDarkL = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--tw-colors-primary-dark-l') ?? '';
+    });
+    // #cc0000 = hsl(0, 100%, 40%)
+    expect(primaryDarkHs).toBe('0, 100%');
+    expect(primaryDarkL).toBe('40%');
+  });
+
+  await test.step('buttonBorderRadius sets --fr-button-border-radius', async () => {
+    const buttonRadius = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--fr-button-border-radius') ?? '';
+    });
+    expect(buttonRadius).toBe('20px');
+  });
+
+  await test.step('cardBorderRadius sets --fr-card-border-radius', async () => {
+    const cardRadius = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--fr-card-border-radius') ?? '';
+    });
+    expect(cardRadius).toBe('16px');
+  });
+});
+
+test('Default widget has no inline theme CSS vars', async ({ page }) => {
+  await page.goto('widget/modal');
+  await page.waitForSelector('.fr_widget-root', { state: 'attached' });
+
+  await test.step('no --tw-colors-primary-dark-hs on root', async () => {
+    const primaryDarkHs = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--tw-colors-primary-dark-hs') ?? '';
+    });
+    expect(primaryDarkHs).toBe('');
+  });
+});
+
+test('Partial theme sets only the provided CSS vars', async ({ page }) => {
+  await page.goto('widget/modal/theme?primaryColor=%23ff6600');
+  await page.waitForSelector('.fr_widget-root', { state: 'attached' });
+
+  await test.step('provided color is applied', async () => {
+    const primaryHs = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--tw-colors-primary-dark-hs') ?? '';
+    });
+    // #ff6600 = hsl(24, 100%, 50%)
+    expect(primaryHs).toBe('24, 100%');
+  });
+
+  await test.step('unset vars are absent', async () => {
+    const buttonRadius = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--fr-button-border-radius') ?? '';
+    });
+    expect(buttonRadius).toBe('');
+  });
+});
+
+test('Invalid hex color is ignored and var is absent', async ({ page }) => {
+  await page.goto('widget/modal/theme?primaryColor=notacolor');
+  await page.waitForSelector('.fr_widget-root', { state: 'attached' });
+
+  await test.step('invalid color produces no CSS var', async () => {
+    const primaryHs = await page.evaluate(() => {
+      const root = document.querySelector('.fr_widget-root');
+      return root?.style.getPropertyValue('--tw-colors-primary-dark-hs') ?? '';
+    });
+    expect(primaryHs).toBe('');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
       "picomatch@4": "4.0.4",
       "uuid": "^14.0.0",
       "ws": ">=8.21.0",
-      "yaml": ">=2.8.3"
+      "yaml": ">=2.8.3",
+      "postcss-selector-parser": ">=6.1.4"
     }
   }
 }

--- a/packages/login-widget/src/lib/custom.base.css
+++ b/packages/login-widget/src/lib/custom.base.css
@@ -31,8 +31,9 @@
   -moz-tab-size: 4; /* 3 */
   -o-tab-size: 4;
   tab-size: 4; /* 3 */
+  color: var(--fr-body-text-color, inherit);
   font-family:
-    'Open Sans',
+    var(--fr-font-family, 'Open Sans'),
     ui-sans-serif,
     system-ui,
     -apple-system,

--- a/packages/login-widget/src/lib/index.svelte
+++ b/packages/login-widget/src/lib/index.svelte
@@ -1,6 +1,6 @@
 <!--
  
- Copyright © 2025 Ping Identity Corporation. All right reserved.
+ Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
  
  This software may be modified and distributed under the terms
  of the MIT license. See the LICENSE file for details.
@@ -26,6 +26,7 @@
   import { onMount } from 'svelte';
 
   import Dialog from '$components/compositions/dialog/dialog.svelte';
+  import { applyThemeVars } from '$core/_effects/theme.effects';
   import { styleStore } from '$core/style.store';
   import Journey from '$journey/journey.svelte';
   import { mount } from './_utilities/component.utilities';
@@ -40,6 +41,9 @@
   let dialogComp: SvelteComponent;
   let dialogEl: HTMLDialogElement;
   let formEl: HTMLFormElement;
+  let widgetRootEl: HTMLDivElement;
+
+  $: applyThemeVars(widgetRootEl, $styleStore?.theme);
 
   onMount(() => {
     mount(dialogComp, dialogEl);
@@ -47,7 +51,7 @@
 </script>
 
 {#if type === 'modal'}
-  <div class="fr_widget-root">
+  <div bind:this={widgetRootEl} class="fr_widget-root">
     <Dialog
       bind:dialogEl
       bind:this={dialogComp}
@@ -64,7 +68,7 @@
     </Dialog>
   </div>
 {:else}
-  <div class="fr_widget-root">
+  <div bind:this={widgetRootEl} class="fr_widget-root">
     <!-- Default `displayIcon` to `true` if `style.stages.icon` is `undefined` or `null` -->
     <Journey
       bind:formEl
@@ -74,3 +78,9 @@
     />
   </div>
 {/if}
+
+<style>
+  .fr_widget-root {
+    font-family: var(--fr-font-family, 'Open Sans'), ui-sans-serif, system-ui, sans-serif;
+  }
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   uuid: ^14.0.0
   ws: '>=8.21.0'
   yaml: '>=2.8.3'
+  postcss-selector-parser: '>=6.1.4'
 
 importers:
 
@@ -387,8 +388,8 @@ importers:
         specifier: ^5.55.7
         version: 5.55.10(@typescript-eslint/types@8.56.1)
       tar:
-        specifier: ^7.5.13
-        version: 7.5.13
+        specifier: ^7.5.16
+        version: 7.5.16
     devDependencies:
       typescript:
         specifier: ^5.2.2
@@ -5039,10 +5040,6 @@ packages:
     peerDependencies:
       postcss: ^8.4.29
 
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
-    engines: {node: '>=4'}
-
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
@@ -5668,8 +5665,8 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar@7.5.13:
-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
   term-size@2.2.1:
@@ -11478,7 +11475,7 @@ snapshots:
   postcss-nested@6.2.0(postcss@8.5.12):
     dependencies:
       postcss: 8.5.12
-      postcss-selector-parser: 6.1.2
+      postcss-selector-parser: 7.1.1
 
   postcss-reporter@7.1.0(postcss@8.5.12):
     dependencies:
@@ -11493,11 +11490,6 @@ snapshots:
   postcss-scss@4.0.9(postcss@8.5.12):
     dependencies:
       postcss: 8.5.12
-
-  postcss-selector-parser@6.1.2:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -12256,7 +12248,7 @@ snapshots:
       postcss-js: 4.1.0(postcss@8.5.12)
       postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.12)(yaml@2.8.3)
       postcss-nested: 6.2.0(postcss@8.5.12)
-      postcss-selector-parser: 6.1.2
+      postcss-selector-parser: 7.1.1
       resolve: 1.22.11
       sucrase: 3.35.1
     transitivePeerDependencies:
@@ -12265,7 +12257,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@7.5.13:
+  tar@7.5.16:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/themes/default/boxes.cjs
+++ b/themes/default/boxes.cjs
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2025 Ping Identity Corporation. All right reserved.
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -13,16 +13,16 @@ module.exports = function (theme) {
      * Container theme settings
      */
     '.containing-box': {
-      '--bg-color': 'hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l))',
+      '--bg-color': `var(--fr-card-bg-color, hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l)))`,
       backgroundColor: `var(--bg-color, ${theme('colors.background.light')})`,
       borderColor: theme('colors.black'),
-      borderRadius: theme('borderRadius.DEFAULT'),
+      borderRadius: `var(--fr-card-border-radius, ${theme('borderRadius.DEFAULT')})`,
       boxShadow: theme('boxShadow.DEFAULT'),
       padding: `${theme('spacing.6')} ${theme('spacing.4')}`,
       width: '500px',
     },
     '.containing-box_dark': {
-      '--bg-color': 'hsl(var(--tw-colors-background-dark-hs),var(--tw-colors-background-dark-l))',
+      '--bg-color': `var(--fr-card-bg-color, hsl(var(--tw-colors-background-dark-hs),var(--tw-colors-background-dark-l)))`,
       backgroundColor: `var(--bg-color, ${theme('colors.background.dark')})`,
     },
     '.containing-box_medium': {

--- a/themes/default/compositions.cjs
+++ b/themes/default/compositions.cjs
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2025 Ping Identity Corporation. All right reserved.
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -121,13 +121,13 @@ module.exports = (config, theme) => ({
    * Dialog box theme settings
    */
   '.dialog-box': {
-    '--bg-color': 'hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l))',
+    '--bg-color': `var(--fr-card-bg-color, hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l)))`,
     '--border':
       '1px solid hsl(var(--tw-colors-secondary-dark-hs),var(--tw-colors-secondary-dark-l))',
     backgroundColor: `var(--bg-color, ${theme('colors.background.light')})`,
     border: `var(--border, 1px solid ${theme('colors.secondary.dark')})`,
     bottom: 0,
-    borderRadius: theme('borderRadius.DEFAULT'),
+    borderRadius: `var(--fr-card-border-radius, ${theme('borderRadius.DEFAULT')})`,
     boxShadow: theme('boxShadow.lg'),
     height: '100%',
     margin: `${theme('spacing.2')} 0 0 0`,
@@ -155,7 +155,7 @@ module.exports = (config, theme) => ({
     },
   },
   '.dialog-box_dark': {
-    '--bg-color': 'hsl(var(--tw-colors-background-dark-hs),var(--tw-colors-background-dark-l))',
+    '--bg-color': `var(--fr-card-bg-color, hsl(var(--tw-colors-background-dark-hs),var(--tw-colors-background-dark-l)))`,
     backgroundColor: `var(--bg-color, ${theme('colors.background.dark')})`,
     borderColor: theme('colors.black'),
 
@@ -167,6 +167,7 @@ module.exports = (config, theme) => ({
     },
   },
   '.dialog-body': {
+    color: `var(--fr-card-text-color, inherit)`,
     margin: `${theme('spacing.10')} ${theme('spacing.6')}`,
   },
   '.dialog-header': {
@@ -177,8 +178,8 @@ module.exports = (config, theme) => ({
     alignItems: 'stretch',
     backgroundColor: `var(--bg-color, ${theme('colors.tertiary.light')})`,
     borderBottom: `var(--border-bottom, 1px solid ${theme('colors.secondary.DEFAULT')})`,
-    borderTopLeftRadius: theme('borderRadius.DEFAULT'),
-    borderTopRightRadius: theme('borderRadius.DEFAULT'),
+    borderTopLeftRadius: `var(--fr-card-border-radius, ${theme('borderRadius.DEFAULT')})`,
+    borderTopRightRadius: `var(--fr-card-border-radius, ${theme('borderRadius.DEFAULT')})`,
     display: 'flex',
     justifyContent: 'center',
     minHeight: theme('spacing.40'),
@@ -248,7 +249,7 @@ module.exports = (config, theme) => ({
     },
   },
   '.dialog-x': {
-    borderRadius: theme('borderRadius.DEFAULT'),
+    borderRadius: `var(--fr-card-border-radius, ${theme('borderRadius.DEFAULT')})`,
     marginRight: theme('spacing.2'),
     position: 'absolute',
     right: theme('spacing.4'),

--- a/themes/default/config.cjs
+++ b/themes/default/config.cjs
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2025 Ping Identity Corporation. All right reserved.
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -16,6 +16,7 @@ const journey = require('./journey.cjs');
 const primitives = require('./primitives.cjs');
 const designTokens = require('./tokens.cjs');
 const utilities = require('./utilities.cjs');
+const { buildTokenVars } = require('./token-vars.cjs');
 
 /**
  * The below theme just extends from the default them found here:
@@ -48,6 +49,7 @@ module.exports = {
    */
   plugins: [
     plugin(({ addComponents, addUtilities, config, theme }) => {
+      const vars = buildTokenVars(theme);
       addComponents({
         /**
          * Non-alpha order is intentional
@@ -56,6 +58,7 @@ module.exports = {
         ...boxes(theme),
         ...compositions(config, theme),
         ...journey(theme),
+        ':where(:root)': vars,
       });
       addUtilities(utilities(theme));
     }),

--- a/themes/default/journey.cjs
+++ b/themes/default/journey.cjs
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2025 Ping Identity Corporation. All right reserved.
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -182,8 +182,7 @@ module.exports = function (theme) {
       },
     },
     '.password-button': {
-      '--bg-color':
-        'hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 2%))',
+      '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 2%)))`,
       backgroundColor: `var(--bg-color, ${colorLib(theme('colors.background.light'))
         .darken(0.02)
         .toString()})`,
@@ -198,7 +197,7 @@ module.exports = function (theme) {
       alignItems: 'center',
     },
     '.password-button_dark': {
-      '--bg-color': 'hsl(var(--tw-colors-body-dark-hs), var(--tw-colors-body-dark-l), 0.5)',
+      '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-body-dark-hs), var(--tw-colors-body-dark-l), 0.5))`,
       backgroundColor: `var(--bg-color, ${colorLib(theme('colors.body.dark'))
         .fade(0.5)
         .toString()})`,

--- a/themes/default/primitives.cjs
+++ b/themes/default/primitives.cjs
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2025 Ping Identity Corporation. All right reserved.
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -155,7 +155,7 @@ module.exports = function (theme) {
       borderColor: `var(--border-color, ${theme('colors.warning.dark')})`,
 
       '& svg': {
-        '--color': `hsl(var(--tw-colors-warning-dark-hs),var(tw-tw-colors-warning-dark-l))`,
+        '--color': `hsl(var(--tw-colors-warning-dark-hs),var(--tw-colors-warning-dark-l))`,
         color: `var(--color, ${theme('colors.warning.dark')})`,
         fill: 'currentColor',
       },
@@ -181,7 +181,7 @@ module.exports = function (theme) {
     '.button-base': {
       // NOTE: Ensure all button have borders for consistent height between regular and outline buttons
       border: `${theme('borderWidth.DEFAULT')} solid`,
-      borderRadius: theme('borderRadius.DEFAULT'),
+      borderRadius: `var(--fr-button-border-radius, ${theme('borderRadius.DEFAULT')})`,
       fontSize: theme('fontSize.base'),
       outlineOffset: '0',
       position: 'relative',
@@ -192,13 +192,16 @@ module.exports = function (theme) {
       '&:focus': {
         outlineOffset: '2px',
       },
+      '&&&:focus': {
+        outlineColor: `var(--fr-button-focus-ring-color, hsl(var(--tw-colors-focus-default-hs),var(--tw-colors-focus-default-l), 0.1))`,
+      },
       '&:active': {
         outlineOffset: '3px',
       },
       '&::before': {
         background: `black`,
         outline: `${theme('borderWidth.DEFAULT')} solid black`,
-        borderRadius: theme('borderRadius.DEFAULT'),
+        borderRadius: `var(--fr-button-border-radius, ${theme('borderRadius.DEFAULT')})`,
         content: '""',
         display: 'block',
         height: '100%',
@@ -219,7 +222,7 @@ module.exports = function (theme) {
       '--border-color': 'hsl(var(--tw-colors-primary-dark-hs),var(--tw-colors-primary-dark-l))',
       backgroundColor: `var(--bg-color, ${theme('colors.primary.dark')})`,
       borderColor: `var(--border-color, ${theme('colors.primary.dark')})`,
-      color: theme('colors.white'),
+      color: `var(--fr-button-text-color, ${theme('colors.white')})`,
       '&:hover::before, &:focus::before': {
         opacity: `0.2`,
       },
@@ -348,8 +351,7 @@ module.exports = function (theme) {
      * String input and select primitive theme settings
      */
     '.input-base': {
-      '--bg-color':
-        'hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 2%))',
+      '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 2%)))`,
       '--border': `${theme(
         'borderWidth.DEFAULT',
       )} solid hsl(var(--tw-colors-secondary-default-hs),var(--tw-colors-secondary-default-l))`,
@@ -359,30 +361,28 @@ module.exports = function (theme) {
         .darken(0.02)
         .toString()})`,
 
-      border: `var(--border, ${theme('borderWidth.DEFAULT')} solid ${theme(
+      border: `var(--fr-input-border, ${theme('borderWidth.DEFAULT')} solid ${theme(
         'colors.secondary.DEFAULT',
       )})`,
-      border: `${theme('borderWidth.DEFAULT')} solid ${theme('colors.secondary.DEFAULT')}`,
       borderRadius: theme('borderRadius.DEFAULT'),
-      color: theme('colors.black'),
+      color: `var(--fr-input-text-color, ${theme('colors.black')})`,
       fontSize: `var(--font-size, ${theme('fontSize.base')})`,
       lineHeight: theme('spacing.6'),
       padding: theme('spacing.3'),
 
       '&:hover': {
-        '--bg-color':
-          'hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l))',
+        '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l)))`,
         backgroundColor: `var(--bg-color, ${theme('colors.background.light')})`,
       },
-      '&:focus': {
-        '--bg-color':
-          'hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l))',
+      '&&:focus': {
+        '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l)))`,
         backgroundColor: `var(--bg-color, ${theme('colors.background.light')})`,
+        outlineColor: `var(--fr-focus-ring-color, hsl(var(--tw-colors-focus-default-hs),var(--tw-colors-focus-default-l), 0.1))`,
+        outlineWidth: '1px',
       },
       '&[aria-invalid="true"]': {
         '--border-color': 'hsl(var(--tw-colors-error-dark-hs),var(--tw-colors-error-dark-l))',
-        '--bg-color':
-          'hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 2%))',
+        '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 2%)))`,
         background: `no-repeat url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='${colorLib(
           theme('colors.error.dark'),
         ).rgb()}' viewBox='0 0 16 16'%3E%3Cpath d='M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8 4a.905.905 0 0 0-.9.995l.35 3.507a.552.552 0 0 0 1.1 0l.35-3.507A.905.905 0 0 0 8 4zm.002 6a1 1 0 1 0 0 2 1 1 0 0 0 0-2z'/%3E%3C/svg%3E");`,
@@ -408,16 +408,14 @@ module.exports = function (theme) {
       // Double class to increase specificity by 1 level
       '&&[aria-invalid="true"]:focus': {
         '--outline-color': 'hsl(var(--tw-colors-error-dark-hs),var(--tw-colors-error-dark-l), 0.3)',
-        '--bg-color':
-          'hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l))',
+        '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l)))`,
         outlineColor: `var(--outline-color, ${colorLib(theme('colors.error.dark'))
           .fade(0.3)
           .toString()})`,
         backgroundColor: `var(--bg-color, ${theme('colors.background.light')})`,
       },
       '&[aria-invalid="true"]:hover': {
-        '--bg-color':
-          'hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l))',
+        '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs),var(--tw-colors-background-light-l)))`,
         backgroundColor: `var(--bg-color, ${theme('colors.background.light')})`,
       },
       // TODO: is this needed? I don't think so.
@@ -426,22 +424,25 @@ module.exports = function (theme) {
       // },
     },
     '.input-base_dark': {
-      '--bg-color': 'hsl(var(--tw-colors-body-dark-hs),var(--tw-colors-body-dark-l), 0.5)',
-      '--border-color': 'hsl(var(--tw-colors-secondary-dark-hs),var(--tw-colors-secondary-dark-l))',
+      '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-body-dark-hs),var(--tw-colors-body-dark-l), 0.5))`,
+      '--border-color': `var(--fr-input-border-color-value, hsl(var(--tw-colors-secondary-dark-hs),var(--tw-colors-secondary-dark-l)))`,
       backgroundColor: `var(--bg-color, ${colorLib(theme('colors.body.dark'))
         .fade(0.5)
         .toString()})`,
       borderColor: `var(--border-color, ${theme('colors.secondary.dark')})`,
-      color: theme('colors.white'),
+      color: `var(--fr-input-text-color, ${theme('colors.white')})`,
 
-      '&:focus': {
-        '--bg-color': 'hsl(var(--tw-colors-body-dark-hs),var(--tw-colors-body-dark-l), 0.25)',
+      // Double-class specificity beats .focusable-element_dark:focus (same variants layer, later source order)
+      '&&:focus': {
+        '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-body-dark-hs),var(--tw-colors-body-dark-l), 0.25))`,
         backgroundColor: `var(--bg-color, ${colorLib(theme('colors.body.dark'))
           .fade(0.25)
           .toString()})`,
+        outlineColor: `var(--fr-focus-ring-color, hsl(var(--tw-colors-focus-default-hs), calc(var(--tw-colors-focus-default-l) + 20%), 0.1))`,
+        outlineWidth: '1px',
       },
       '&:hover': {
-        '--bg-color': 'hsl(var(--tw-colors-body-dark-hs),var(--tw-colors-body-dark-l), 0.25)',
+        '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-body-dark-hs),var(--tw-colors-body-dark-l), 0.25))`,
         backgroundColor: `var(--bg-color, ${colorLib(theme('colors.body.dark'))
           .fade(0.25)
           .toString()})`,
@@ -486,13 +487,13 @@ module.exports = function (theme) {
 
     '.input-label': {
       '--font-size': 'var(--tw-font-size-base-type)',
-      '--color': 'hsl(var(--tw-colors-label-dark-hs), var(--tw-colors-label-dark-l))',
+      '--color': `var(--fr-input-label-color, hsl(var(--tw-colors-label-dark-hs), var(--tw-colors-label-dark-l)))`,
       fontSize: `var(--font-size, ${theme('fontSize.base')})`,
       color: `var(--color, ${theme('colors.label.dark')})`,
     },
 
     '.input-label_dark': {
-      '--color': 'hsl(var(--tw-colors-label-light-hs),var(--tw-colors-label-light-l))',
+      '--color': `var(--fr-input-label-color, hsl(var(--tw-colors-label-light-hs),var(--tw-colors-label-light-l)))`,
       color: `var(--color, ${theme('colors.label.light')})`,
 
       ':where(input:autofill) + &': {
@@ -560,10 +561,10 @@ module.exports = function (theme) {
       color: `var(--color, ${theme('colors.link.light')})`,
     },
     '.select-base': {
-      '--bg-color':
-        'hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 2%))',
+      '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 2%)))`,
       '--color': 'hsl(var(--tw-colors-label-dark-hs), var(--tw-colors-label-dark-l))',
 
+      accentColor: `var(--fr-select-accent-color, hsl(var(--tw-colors-primary-dark-hs),var(--tw-colors-primary-dark-l)))`,
       appearance: 'none',
       /**
        * The below background property prevents Storybook a11y from determining contrast.
@@ -583,22 +584,21 @@ module.exports = function (theme) {
       height: 'calc(3rem + 2px)',
 
       '&:hover': {
-        '--bg-color':
-          'hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 5%))',
+        '--bg-color': `var(--fr-select-hover-bg-color, var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 5%))))`,
         backgroundColor: `var(--bg-color, ${colorLib(theme('colors.background.light'))
           .darken(0.05)
           .toString()})`,
       },
-      '&:focus': {
-        '--bg-color':
-          'hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 5%))',
+      '&&:focus': {
+        '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 5%)))`,
         backgroundColor: `var(--bg-color, ${colorLib(theme('colors.background.light'))
           .darken(0.05)
           .toString()})`,
+        outlineColor: `var(--fr-focus-ring-color, hsl(var(--tw-colors-focus-default-hs),var(--tw-colors-focus-default-l), 0.1))`,
+        outlineWidth: '1px',
       },
       '&[aria-invalid="true"]': {
-        '--bg-color':
-          'hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 2%))',
+        '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-background-light-hs), calc(var(--tw-colors-background-light-l) - 2%)))`,
 
         backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='${colorLib(
           theme('colors.secondary.dark'),
@@ -613,8 +613,9 @@ module.exports = function (theme) {
       },
     },
     '.select-base_dark': {
-      '--bg-color': 'hsl(var(--tw-colors-body-dark-hs), var(--tw-colors-body-dark-l), 0.5)',
+      '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-body-dark-hs), var(--tw-colors-body-dark-l), 0.5))`,
       '--color': 'hsl(var(--tw-colors-label-light-hs), var(--tw-colors-label-light-l))',
+      accentColor: `var(--fr-select-accent-color, hsl(var(--tw-colors-primary-light-hs),var(--tw-colors-primary-light-l)))`,
       background: `no-repeat right ${theme(
         'spacing.3',
       )} center / 16px 12px url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='${colorLib(
@@ -626,17 +627,20 @@ module.exports = function (theme) {
       color: `var(--color, ${theme('colors.label.light')})`,
 
       '&:hover,': {
-        '--bg-color': 'hsl(var(--tw-colors-body-dark-hs), var(--tw-colors-body-dark-l), 0.25)',
+        '--bg-color': `var(--fr-select-hover-bg-color, var(--fr-input-bg-color, hsl(var(--tw-colors-body-dark-hs), var(--tw-colors-body-dark-l), 0.25)))`,
         backgroundColor: `var(--bg-color, ${colorLib(theme('colors.body.dark'))
           .fade(0.25)
           .toString()})`,
       },
 
-      '&:focus': {
-        '--bg-color': 'hsl(var(--tw-colors-body-dark-hs), var(--tw-colors-body-dark-l), 0.25)',
+      // Double-class specificity beats .focusable-element_dark:focus (same variants layer, later source order)
+      '&&:focus': {
+        '--bg-color': `var(--fr-input-bg-color, hsl(var(--tw-colors-body-dark-hs), var(--tw-colors-body-dark-l), 0.25))`,
         backgroundColor: `var(--bg-color, ${colorLib(theme('colors.body.dark'))
           .fade(0.25)
           .toString()})`,
+        outlineColor: `var(--fr-focus-ring-color, hsl(var(--tw-colors-focus-default-hs), calc(var(--tw-colors-focus-default-l) + 20%), 0.1))`,
+        outlineWidth: '1px',
       },
 
       '&[aria-invalid="true"]': {

--- a/themes/default/token-vars.cjs
+++ b/themes/default/token-vars.cjs
@@ -1,0 +1,70 @@
+/**
+ *
+ * Copyright © 2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+const colorLib = require('color');
+
+const TOKEN_MAPPINGS = [
+  ['colors.background.dark', 'background-dark'],
+  ['colors.background.light', 'background-light'],
+  ['colors.body.dark', 'body-dark'],
+  ['colors.body.light', 'body-light'],
+  ['colors.error.dark', 'error-dark'],
+  ['colors.error.light', 'error-light'],
+  ['colors.focus.DEFAULT', 'focus-default'],
+  ['colors.header.dark', 'header-dark'],
+  ['colors.header.light', 'header-light'],
+  ['colors.label.dark', 'label-dark'],
+  ['colors.label.light', 'label-light'],
+  ['colors.link.dark', 'link-dark'],
+  ['colors.link.light', 'link-light'],
+  ['colors.primary.dark', 'primary-dark'],
+  ['colors.primary.light', 'primary-light'],
+  ['colors.primary.off', 'primary-off'],
+  ['colors.secondary.dark', 'secondary-dark'],
+  ['colors.secondary.DEFAULT', 'secondary-default'],
+  ['colors.secondary.light', 'secondary-light'],
+  ['colors.success.dark', 'success-dark'],
+  ['colors.success.light', 'success-light'],
+  ['colors.tertiary.dark', 'tertiary-dark'],
+  ['colors.tertiary.light', 'tertiary-light'],
+  ['colors.warning.dark', 'warning-dark'],
+  ['colors.warning.light', 'warning-light'],
+];
+
+function hexToHslChannels(hex) {
+  const c = colorLib(hex);
+  const [h, s, l] = c.hsl().color;
+  return {
+    hs: `${Math.round(h * 10) / 10}, ${Math.round(s * 10) / 10}%`,
+    l: `${Math.round(l * 10) / 10}%`,
+  };
+}
+
+/**
+ * Builds the --tw-colors-* CSS custom property map from resolved Tailwind token values.
+ * @param {function} theme - Tailwind's theme() resolver
+ * @returns {Record<string, string>}
+ */
+function buildTokenVars(theme) {
+  const vars = {};
+  for (const [tokenPath, varName] of TOKEN_MAPPINGS) {
+    const hex = theme(tokenPath);
+    if (!hex) continue;
+    try {
+      const { hs, l } = hexToHslChannels(hex);
+      vars[`--tw-colors-${varName}-hs`] = hs;
+      vars[`--tw-colors-${varName}-l`] = l;
+    } catch {
+      // skip invalid hex
+    }
+  }
+  return vars;
+}
+
+module.exports = { buildTokenVars };

--- a/themes/default/tokens.cjs
+++ b/themes/default/tokens.cjs
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2025 Ping Identity Corporation. All right reserved.
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -51,6 +51,7 @@ module.exports = {
        * for use as a background with white text
        */
       light: colorLib(colors.sky[600]).darken(0.075).hex(),
+      off: colors.slate[700],
     },
     tertiary: {
       dark: colors.slate[800],

--- a/themes/default/utilities.cjs
+++ b/themes/default/utilities.cjs
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright © 2025 Ping Identity Corporation. All right reserved.
+ * Copyright © 2025-2026 Ping Identity Corporation. All right reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -25,8 +25,7 @@ module.exports = (theme) => ({
     transition:
       'background-color ease-in-out 0.15s, outline-color ease-in-out 0.2s, outline-offset ease-in-out 0.1s',
     '&:focus': {
-      '--outline-color':
-        'hsl(var(--tw-colors-focus-default-hs),var(--tw-colors-focus-default-l), 0.1)',
+      '--outline-color': `hsl(var(--tw-colors-focus-default-hs),var(--tw-colors-focus-default-l), 0.1)`,
       outlineOffset: '0',
       outlineWidth: '3px',
       outlineColor: `var(--outline-color, ${colorLib(theme('ringColor.DEFAULT'))
@@ -46,8 +45,7 @@ module.exports = (theme) => ({
       .fade(0.7)
       .toString()})`,
     '&:focus': {
-      '--outline-color':
-        'hsl(var(--tw-colors-focus-default-hs), calc(var(--tw-colors-focus-default-l) + 20%), 0.1)',
+      '--outline-color': `hsl(var(--tw-colors-focus-default-hs), calc(var(--tw-colors-focus-default-l) + 20%), 0.1)`,
       outlineColor: `var(--outline-color, ${colorLib(theme('ringColor.DEFAULT'))
         .lighten(0.2)
         .fade(0.1)

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -41,7 +41,7 @@
     "@effect/typeclass": "^0.40.0",
     "effect": "^3.21.0",
     "svelte": "^5.55.7",
-    "tar": "^7.5.13"
+    "tar": "^7.5.16"
   },
   "devDependencies": {
     "typescript": "^5.2.2",


### PR DESCRIPTION
## Summary

https://pingidentity.atlassian.net/browse/SDKS-5079

Adds IDM-driven theming to the Login Widget and Login App. Consumers pass design tokens via
`await configure({ style: { theme } })`. The Login App SSR layer fetches the active IDM theme
from `/openidm/config/ui/themerealm` on each page load and applies it as CSS custom properties
before the initial HTML is sent, so there is no flash of unstyled content.

## Changes

### `core/style.store.ts`

- `themeSchema` (Zod): validates all supported theme fields. Hex fields use a strict 6/8-digit
  regex with `.catch(undefined)` so an invalid value degrades to unset instead of discarding the
  whole theme. `logo` / `favicon` are URL-validated, `fontFamily` is regex-validated (CSS
  injection guard).
- `ThemeObject` type export. Field names match the internal CSS var they target
  (`buttonBorderRadius` -> `--fr-button-border-radius`).
- `styleSchema` extended with `theme: themeSchema.optional()`.
- `urlRegex` exported for reuse in `idm-theme.effects.ts`.

### `core/_utilities/theme.utilities.ts` _(new)_

- `hexToHslChannels(hex)` -> `{ hs: "H, S%", l: "L%" }`. Accepts 6- or 8-digit hex (alpha
  stripped), throws on anything else. Channels stay split because component classes reference
  them independently, e.g. `calc(var(--tw-colors-*-l) - 10%)`.
- `buildThemeVarsEntries(theme)` -> `[string, string][]` of CSS var declarations. Pure mapping
  core shared by the SSR path (`+layout.svelte`) and the DOM path (`applyThemeVars`). Invalid
  hex per field is skipped silently.
- `encodeCssUrl(url)` -> `url("…")` with `"` percent-encoded, preventing breakout from a quoted
  `url()` inside an inline `style` attribute.

Notable mappings: `primaryColor` fills both primary-dark and primary-light slot pairs;
`secondaryColor` fills all three secondary pairs (dark/default/light); `backgroundColor` fills
the background pairs plus `--fr-page-bg-color`; `inputFocusRingColor` sets only
`--fr-focus-ring-color`, deliberately not the shared `--tw-colors-focus-default-*`, so button and
link focus transitions are unaffected.

### `core/_effects/theme.effects.ts` _(new)_

- `applyThemeVars(rootEl, theme)` — DOM side-effect wrapper over `buildThemeVarsEntries`; noop
  when either argument is absent. Used by the widget standalone path.

### `packages/login-widget/src/lib/index.svelte`

- `bind:this={widgetRootEl}` on both modal and inline roots.
- `$: applyThemeVars(widgetRootEl, $styleStore?.theme)` reapplies on every store update.

### `packages/login-widget/src/lib/custom.base.css`

- `:where(.fr_widget-root)` gains `color: var(--fr-body-text-color, inherit)` and
  `var(--fr-font-family, 'Open Sans')` at the head of the font stack.

### `themes/default/token-vars.cjs` _(new)_

- `buildTokenVars(theme)` — Tailwind plugin helper. Resolves 25 token paths through Tailwind's
  `theme()` resolver, converts each hex to an HSL channel pair, and returns a
  `Record<string, string>` of `--tw-colors-*-hs` / `-l` vars.

### `themes/default/config.cjs`

- Plugin merges `':where(:root)': buildTokenVars(theme)` into `addComponents`, covering both the
  login-app and widget standalone builds. Specificity 0, so any consumer `:root {}` or IDM inline
  style wins.

### `themes/default/tokens.cjs`

- New `colors.primary.off` token (`slate.700`), target of `primaryOffColor`.

### `themes/default/primitives.cjs`

New CSS var slots: `--fr-button-border-radius` on `.button-base`; `--fr-input-text-color` on
`.input-base` / `_dark`; `--fr-button-text-color` on `.button-primary`; `--fr-input-bg-color` on
`.input-base`, `.select-base`, `.password-button` and their dark and hover/focus states;
`--fr-input-border` / `--fr-input-border-color-value` on input borders; `--fr-input-label-color`
on `.input-label` / `_dark`; `--fr-button-focus-ring-color` on `.button-base:focus`, isolated
from the input focus ring; `--fr-focus-ring-color` on input and select `:focus`;
`--fr-select-accent-color` / `--fr-select-hover-bg-color` on select states. The 3px focus ring is
restored on `.focusable-element:focus`; the 1px ring is scoped to input and select only.

### `themes/default/boxes.cjs`, `compositions.cjs`, `utilities.cjs`, `journey.cjs`

- `--fr-card-bg-color` on `.dialog-box`, `.containing-box` and dark variants.
- `--fr-card-border-radius` on `.dialog-box`, `.dialog-header` (top corners), `.dialog-x`,
  `.containing-box`.
- `--fr-card-text-color` with `inherit` fallback on `.dialog-body`.
- `--fr-focus-ring-color`, `--fr-select-accent-color`, `--fr-select-hover-bg-color` on
  `.focusable-element:focus`, `accent-color`, select hover.
- `--fr-input-bg-color` fallback wrapper around select `--bg-color` in light and dark.

### `apps/login-app/src/lib/server/idm-theme.effects.ts` _(new)_

- `fetchIdmTheme(idmBaseUrl, realmPath, journeyName)` — anonymous GET of
  `/openidm/config/ui/themerealm`. Resolves the active theme by `?journey=` -> `linkedTrees` ->
  `isDefault` -> first entry. Validates through `themeSchema.safeParse()`. Returns `undefined`
  theme on any failure. Default 1500ms timeout via `AbortSignal.timeout`, overridable with
  `FR_IDM_THEME_TIMEOUT_MS`. Module-level cache keyed `realm::journey`; every failure path falls
  back to the last successful result before falling back to widget defaults.
- `toIdmTheme()` — translates IDM external field names (`buttonRounded`) to internal
  `ThemeObject` names (`buttonBorderRadius`); drops invalid logo/favicon URLs individually.
- Returns `{ theme, backgroundImageUrl }`.

### `apps/login-app/src/routes/(app)/+layout.server.ts`

- `idmBaseUrl = env.FR_IDM_URL ?? env.FR_AM_URL` — IDM can be pointed at a separate host.
- `journeyName = url.searchParams.get('journey') ?? env.FR_AM_JOURNEY_LOGIN ?? null`.
- Returns `idmTheme` and `backgroundImageUrl`; all IDM logic stays in `idm-theme.effects.ts`.

### `apps/login-app/src/routes/(app)/+layout.ts`

- Calls `initializeStyles({ theme: data.idmTheme, logo: { light, dark, height } })` when
  `idmTheme` is defined; `logo` is only spread in when `idmTheme.logo` is present.

### `apps/login-app/src/routes/(app)/+layout.svelte`

- Theme vars serialized into an inline `style` attribute on `<div class="theme-root">`, present
  in the initial HTML. No `{@html}`; Svelte escapes the attribute value.
- `--fr-page-bg-image` set from `data.backgroundImageUrl` in the same attribute.
- `<link rel="icon" href={data.idmTheme?.favicon ?? '/favicon.ico'} />`.

### `core/journey/stages/generic.svelte`, `login.svelte`

- Logo rendered from `$styleStore.logo` at the IDM-specified height (default 72x200), guarded
  with `componentStyle !== 'modal'` so it does not double-render in modal mode. URLs pass through
  `encodeCssUrl()`.

### `core/components/compositions/dialog/dialog.svelte`

- Existing logo `url()` interpolations replaced with `encodeCssUrl()`.

### `core/components/primitives/box/centered.svelte`

- `.page-shell` reads `--fr-page-bg-color` with an `hsl(var(--tw-colors-body-light-*))` fallback
  (body-dark under `.dark` and `prefers-color-scheme: dark`), plus `--fr-page-bg-image` and
  `--fr-font-family`.

### Config / tooling

- `.npmrc`: `public-hoist-pattern[]=@effect/*`, `public-hoist-pattern[]=effect`.
- `.env.example`, `.env.docker.example`: document optional `FR_AM_JOURNEY_LOGIN`.
- `core/style.stories.js` / `style.story.svelte`: `ThemeOverride` story under `Style/Config`.
- `apps/login-app/src/routes/e2e/widget/{inline,modal}/theme/+page.svelte`: E2E fixtures.
- Changeset: `@forgerock/login-widget` minor.

  ## Tests

  | File | Tests | Coverage |
  |------|-------|----------|
  | `core/_utilities/theme.utilities.test.ts` _(new)_ | 18 | `hexToHslChannels`,
  `buildThemeVarsEntries`, `encodeCssUrl` |
  | `core/_effects/theme.effects.test.ts` _(new)_ | 27 | `applyThemeVars` DOM application,
  all field groups |
  | `core/style.store.test.ts` _(new)_ | 23 | `themeSchema` validation, `styleSchema`
  extension, `initialize()` integration |
  | `apps/login-app/src/lib/server/idm-theme.effects.test.ts` _(new)_ | 15 | `fetchIdmTheme`
  resolution logic, cache fallback, graceful degradation |
  | `e2e/tests/widget/modal/widget-modal.theme.test.js` _(new)_ | 4 | CSS vars applied from
  API; no vars on default; partial theme; invalid hex ignored |

  **245/245 unit tests pass · 4/4 E2E theme tests pass**

  ## How to test

  ### 1. Widget theme API (no server required)

  ```js
  import { configuration } from '@forgerock/login-widget';

  configuration({
    style: {
      theme: {
        primaryColor: '#cc0000',
        buttonBorderRadius: 20,
        cardBorderRadius: 16,
      },
    },
  });

  Inspect .fr_widget-root in DevTools — --tw-colors-primary-dark-hs,
  --tw-colors-primary-dark-l, --fr-button-border-radius, --fr-card-border-radius should all
  be set.

  2. Storybook visual check

  pnpm storybook

  Open Style › ThemeOverride — button red, card corners rounded. Open Style › Default — no
  inline CSS vars, no visual change.

  3. Login App SSR integration

  Set FR_AM_URL to an AM instance with IDM co-located. Set FR_AM_JOURNEY_LOGIN=Login. Load
  /?journey=Login. The login card should render using the IDM theme for the Login tree.
  Confirm --fr-card-bg-color, --fr-input-bg-color, logo, and primaryColor match IDM values
  and are present in the initial HTML (view source — not just DevTools).

  4. Fallback / negative path

  Point FR_AM_URL at an unreachable host. Page should load with widget defaults — no error
  thrown, no broken layout.

  5. Run unit and E2E tests

  pnpm --filter @forgerock/login-widget exec vitest run 'theme'
  pnpm --filter @forgerock/login-widget exec vitest run 'style.store'
  pnpm --filter @forgerock/login-app test
  pnpm build:app && pnpm ci:e2e -- tests/widget/modal/widget-modal.theme.test.js

