### PR TITLE
2.1 release upgrades for journey client migration

### DIFF
--- a/.changeset/tall-hornets-double.md
+++ b/.changeset/tall-hornets-double.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/login-widget': patch
+---
+
+Adopt journey-client 2.1: import types from the package instead of deriving them, include login failure type and remove resume() URL-parsing.

--- a/core/journey/callbacks/_utilities/callback.utilities.ts
+++ b/core/journey/callbacks/_utilities/callback.utilities.ts
@@ -11,6 +11,7 @@ import { interpolate } from '$core/_utilities/i18n.utilities';
 
 import type {
   AttributeInputCallback,
+  PolicyParams,
   PolicyRequirement,
   ValidatedCreatePasswordCallback,
   ValidatedCreateUsernameCallback,
@@ -26,8 +27,7 @@ export interface Policy {
   params: Record<string, unknown>;
 }
 export interface FailedPolicy {
-  // TODO: PolicyParams must be re-exported by journey-client from forgerock/sdk-types, until then we derive the type like below
-  params: PolicyRequirement['params'];
+  params?: Partial<PolicyParams>;
   policyRequirement: string;
   restructured: RestructuredParam[];
 }

--- a/core/journey/journey.interfaces.ts
+++ b/core/journey/journey.interfaces.ts
@@ -13,18 +13,12 @@ import type {
   ResumeOptions,
   StartParam,
   Step,
+  StepDetail,
 } from '@forgerock/journey-client/types';
 import type { ComponentConstructorOptions, SvelteComponent } from 'svelte';
 import type { Writable } from 'svelte/store';
 
 import type { Maybe } from '$core/interfaces';
-
-/*
- * TODO: Journey Client does not export StepDetail
- * This should be replaced with an import from journey-client/types
- * when Journey Client starts exporting StepDetail
- */
-type StepDetail = NonNullable<Step['detail']>;
 
 export type CaptchaMode = 'visible' | 'invisible';
 

--- a/core/journey/journey.store.test.ts
+++ b/core/journey/journey.store.test.ts
@@ -159,4 +159,159 @@ describe('journey.store (Journey Client configuration)', () => {
     await expect(getJourneyClient()).resolves.toBe(client2);
     expect(journeyMock).toHaveBeenCalledTimes(2);
   });
+
+  /**
+   * A LoginFailure result must route through the LoginFailure branch, which is the only
+   * branch that threads `failureResult` into the error state — so `error.code` reflects
+   * `failureResult.getCode()`. (`error.message` derives from `htmlDecode`, which returns
+   * null in this non-DOM test environment; the message text is covered end-to-end by E2E.)
+   */
+  it('routes a LoginFailure result through the LoginFailure branch, surfacing its code', async () => {
+    const loginFailure = {
+      type: 'LoginFailure' as const,
+      payload: { message: 'User Locked Out.', detail: null },
+      getCode: () => 401,
+    };
+    const restartError = {
+      type: 'unknown_error' as const,
+      error: 'restart_failed',
+      message: 'restart failed',
+    };
+
+    const client = {
+      start: vi.fn().mockResolvedValueOnce(loginFailure).mockResolvedValueOnce(restartError),
+      next: vi.fn(),
+    } as unknown as JourneyClient;
+
+    journeyMock.mockResolvedValue(client);
+
+    const { initialize, journeyStore } = await importSubject();
+    const store = initialize({
+      serverConfig: {
+        wellknown: 'https://example.com/.well-known/openid-configuration',
+      },
+    });
+
+    await store.start({ journey: 'Login' });
+
+    const { get } = await import('svelte/store');
+    const state = get(journeyStore);
+
+    // code 401 comes only from failureResult.getCode() — proves the LoginFailure branch ran.
+    expect(state.error?.code).toBe(401);
+  });
+
+  /**
+   * A GenericError result (genuine transport failure) should fall through to the
+   * network-error message — the path the removed no_response_data hack used to shortcut.
+   */
+  it('routes a GenericError result through the network-error branch using its message', async () => {
+    const genericError = {
+      type: 'unknown_error' as const,
+      error: 'no_response_data',
+      message: 'No data received from server',
+    };
+    const restartError = {
+      type: 'unknown_error' as const,
+      error: 'restart_failed',
+      message: 'restart failed',
+    };
+
+    const client = {
+      start: vi.fn().mockResolvedValueOnce(genericError).mockResolvedValueOnce(restartError),
+      next: vi.fn(),
+    } as unknown as JourneyClient;
+
+    journeyMock.mockResolvedValue(client);
+
+    const { initialize, journeyStore } = await importSubject();
+    const store = initialize({
+      serverConfig: {
+        wellknown: 'https://example.com/.well-known/openid-configuration',
+      },
+    });
+
+    await store.start({ journey: 'Login' });
+
+    const { get } = await import('svelte/store');
+    const state = get(journeyStore);
+
+    expect(state.error?.message).toBe('No data received from server');
+  });
+
+  /**
+   * Journey Client parses the legacy resume URL params itself, so the store forwards the
+   * URL untouched — except a `journey` query param, which the client does not read and the
+   * store therefore threads through as a resume option.
+   */
+  it('forwards a journey query param from the resume URL to journeyClient.resume', async () => {
+    const loginSuccess = { type: 'LoginSuccess' as const, payload: { tokenId: 'abc' } };
+
+    const resumeSpy = vi.fn().mockResolvedValueOnce(loginSuccess);
+    const client = { start: vi.fn(), next: vi.fn(), resume: resumeSpy } as unknown as JourneyClient;
+
+    journeyMock.mockResolvedValue(client);
+
+    const { initialize } = await importSubject();
+    const store = initialize({
+      serverConfig: {
+        wellknown: 'https://example.com/.well-known/openid-configuration',
+      },
+    });
+
+    const resumeUrl = 'https://example.com/callback?suspendedId=abc123&journey=ResetPassword';
+    await store.resume(resumeUrl);
+
+    expect(resumeSpy).toHaveBeenCalledWith(resumeUrl, { journey: 'ResetPassword' });
+  });
+
+  /**
+   * When both the URL and resumeOptions carry a `journey`, the URL value wins — preserving
+   * the precedence the store had before it delegated legacy-param parsing to Journey Client.
+   */
+  it('prioritizes the URL journey query param over resumeOptions.journey', async () => {
+    const loginSuccess = { type: 'LoginSuccess' as const, payload: { tokenId: 'abc' } };
+
+    const resumeSpy = vi.fn().mockResolvedValueOnce(loginSuccess);
+    const client = { start: vi.fn(), next: vi.fn(), resume: resumeSpy } as unknown as JourneyClient;
+
+    journeyMock.mockResolvedValue(client);
+
+    const { initialize } = await importSubject();
+    const store = initialize({
+      serverConfig: {
+        wellknown: 'https://example.com/.well-known/openid-configuration',
+      },
+    });
+
+    const resumeUrl = 'https://example.com/callback?suspendedId=abc123&journey=ResetPassword';
+    await store.resume(resumeUrl, { journey: 'Login' });
+
+    expect(resumeSpy).toHaveBeenCalledWith(resumeUrl, { journey: 'ResetPassword' });
+  });
+
+  /**
+   * Without a `journey` query param the store forwards the URL and options unchanged,
+   * leaving all legacy-param parsing to Journey Client.
+   */
+  it('forwards the resume URL untouched when no journey query param is present', async () => {
+    const loginSuccess = { type: 'LoginSuccess' as const, payload: { tokenId: 'abc' } };
+
+    const resumeSpy = vi.fn().mockResolvedValueOnce(loginSuccess);
+    const client = { start: vi.fn(), next: vi.fn(), resume: resumeSpy } as unknown as JourneyClient;
+
+    journeyMock.mockResolvedValue(client);
+
+    const { initialize } = await importSubject();
+    const store = initialize({
+      serverConfig: {
+        wellknown: 'https://example.com/.well-known/openid-configuration',
+      },
+    });
+
+    const resumeUrl = 'https://example.com/callback?suspendedId=abc123&authIndexValue=Login';
+    await store.resume(resumeUrl);
+
+    expect(resumeSpy).toHaveBeenCalledWith(resumeUrl, undefined);
+  });
 });

--- a/core/journey/journey.store.ts
+++ b/core/journey/journey.store.ts
@@ -26,6 +26,7 @@ import type {
   GenericError,
   JourneyClient,
   JourneyClientConfig,
+  JourneyResult,
   JourneyStep,
   NextOptions,
   ResumeOptions,
@@ -201,8 +202,6 @@ export function initialize(
   const stack = initializeStack();
   let stepNumber = 0;
   let currentRecaptchaAction: string | null = null;
-  // TODO: JourneyResult is not currently exported by Journey Client, so we define it here
-  type JourneyResult = Awaited<ReturnType<JourneyClient['start']>>;
 
   async function start(startOptions?: StartParam, recaptchaAction?: string) {
     // Falls back to journey name (e.g. "Login") when no explicit recaptchaAction is given —
@@ -278,49 +277,15 @@ export function initialize(
     try {
       const journeyClient = await getJourneyClient();
       /**
-       * Journey Client `resume()` already parses: `code`, `state`, `form_post_entry`, `responsekey`.
-       * We only parse the legacy URL params that Journey Client does NOT currently support.
+       * Journey Client `resume()` parses the legacy URL params itself (error, errorCode,
+       * errorMessage, nonce, RelayState, scope, suspendedId, authIndexValue, plus the
+       * redirect params code/state/form_post_entry/responsekey). The one thing it does not
+       * read is a `journey` query param, so forward that through when present.
        */
-      let updatedResumeOptions = resumeOptions;
-
-      try {
-        const parsedUrl = new URL(url);
-        const params = parsedUrl.searchParams;
-
-        const error = params.get('error');
-        const errorCode = params.get('errorCode');
-        const errorMessage = params.get('errorMessage');
-        const nonce = params.get('nonce');
-        const scope = params.get('scope');
-        const RelayState = params.get('RelayState');
-        const suspendedId = params.get('suspendedId');
-        const authIndexValue = params.get('authIndexValue');
-        const journeyParam =
-          params.get('journey') || resumeOptions?.journey || authIndexValue || undefined;
-
-        /**
-         * URL-derived params can override resumeOptions query property
-         * RelayState is PascalCase to match the property name that AM expects
-         */
-        const mergedQuery = {
-          ...resumeOptions?.query,
-          ...(error && { error }),
-          ...(errorCode && { errorCode }),
-          ...(errorMessage && { errorMessage }),
-          ...(nonce && { nonce }),
-          ...(RelayState && { RelayState }),
-          ...(scope && { scope }),
-          ...(suspendedId && { suspendedId }),
-        };
-
-        updatedResumeOptions = {
-          ...(journeyParam && { journey: journeyParam }),
-          ...(mergedQuery && { query: mergedQuery }),
-        };
-      } catch {
-        // If URL parsing fails, fall back to the provided `resumeOptions` unchanged.
-        updatedResumeOptions = resumeOptions;
-      }
+      const journeyParam = new URL(url).searchParams.get('journey');
+      const updatedResumeOptions = journeyParam
+        ? { ...resumeOptions, journey: journeyParam }
+        : resumeOptions;
 
       result = await journeyClient.resume(url, updatedResumeOptions);
     } catch (err) {
@@ -442,16 +407,7 @@ export function initialize(
       // Handle GenericError case
       const genericError = result;
       const errorMessage =
-        /**
-         * TODO: Journey Client currently does not handle JourneyLoginFailure case
-         * It returns a GenericError type when it should be returning JourneyLoginFailure type
-         * The hack below temporarily passes failing tests for Login journey
-         * Remove this check when https://github.com/ForgeRock/ping-javascript-sdk/pull/574
-         * PR has been merged and journey client is published to npm
-         */
-        genericError.error === 'no_response_data' && context?.prevStep
-          ? interpolate('loginFailure')
-          : genericError.message ?? genericError.error ?? interpolate('unknownNetworkError');
+        genericError.message ?? genericError.error ?? interpolate('unknownNetworkError');
 
       await restartJourney(errorMessage, context);
     }

--- a/core/journey/stages/_utilities/step.utilities.test.ts
+++ b/core/journey/stages/_utilities/step.utilities.test.ts
@@ -17,11 +17,7 @@ import {
   shouldPopulateWithPreviousCallbacks,
 } from './step.utilities';
 
-import type { JourneyClient, Step } from '@forgerock/journey-client/types';
-
-// TODO: JourneyResult and JourneyLoginFailure are not currently exported by Journey Client, so we define them here
-type JourneyResult = Awaited<ReturnType<JourneyClient['start']>>;
-type JourneyLoginFailure = Extract<JourneyResult, { type: 'LoginFailure' }>;
+import type { JourneyLoginFailure, Step } from '@forgerock/journey-client/types';
 
 function createLoginFailure(payload: Step): JourneyLoginFailure {
   return {

--- a/core/journey/stages/_utilities/step.utilities.ts
+++ b/core/journey/stages/_utilities/step.utilities.ts
@@ -9,14 +9,15 @@
 
 import { callbackType } from '@forgerock/journey-client';
 
-import type { BaseCallback, JourneyClient, JourneyStep } from '@forgerock/journey-client/types';
+import type {
+  BaseCallback,
+  JourneyLoginFailure,
+  JourneyResult,
+  JourneyStep,
+} from '@forgerock/journey-client/types';
 
 export const authIdTimeoutErrorCode = '110';
 export const constrainedViolationMessage = 'constraint violation';
-
-// TODO: JourneyResult and JourneyLoginFailure are not currently exported by Journey Client, so we define them here
-type JourneyResult = Awaited<ReturnType<JourneyClient['start']>>;
-type JourneyLoginFailure = Extract<JourneyResult, { type: 'LoginFailure' }>;
 
 /**
  * @function convertStringToKey -

--- a/e2e/tests/widget/inline/widget-inline.login-failure.test.js
+++ b/e2e/tests/widget/inline/widget-inline.login-failure.test.js
@@ -1,0 +1,43 @@
+/**
+ *
+ * Copyright © 2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { expect, test } from '@playwright/test';
+
+import { asyncEvents } from '../../utilities/async-events.js';
+
+/**
+ * Inline-widget coverage for the login-failure path. The failure logic lives in the
+ * shared journey store, but the inline presentation renders the form differently from
+ * the modal, so this guards inline-specific rendering of the failure state under
+ * journey-client 2.1's LoginFailure result.
+ */
+test('Inline widget surfaces a login failure and keeps the form usable', async ({ page }) => {
+  const { clickButton, navigate } = asyncEvents(page);
+
+  const messageArray = [];
+  page.on('console', (msg) => messageArray.push(msg.text()));
+
+  await navigate('widget/inline?journey=TEST_Login');
+
+  // Inline auto-renders the form on mount — submit invalid credentials straight away.
+  await page.getByRole('textbox', { name: 'Username' }).fill('notauser');
+  await page.getByRole('textbox', { name: 'Password' }).fill('notapassword');
+
+  await clickButton('Sign In', '/authenticate');
+
+  // Failure message renders...
+  await expect(page.getByText('Sign in failed')).toBeVisible();
+
+  // ...the journey onFailure() event fires...
+  expect(messageArray.includes('Login failure event fired')).toBe(true);
+
+  // ...and the form restarts usable (not a dead end).
+  await expect(page.getByRole('textbox', { name: 'Username' })).toBeEditable();
+  await expect(page.getByRole('textbox', { name: 'Password' })).toBeEditable();
+});

--- a/e2e/tests/widget/inline/widget-inline.resume.test.js
+++ b/e2e/tests/widget/inline/widget-inline.resume.test.js
@@ -1,0 +1,46 @@
+/**
+ *
+ * Copyright © 2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { expect, test } from '@playwright/test';
+
+/**
+ * Inline-widget resume-from-URL. When the inline harness mounts with a suspendedId (as an
+ * email magic link would land the user), it auto-calls journey.resume(location.href).
+ * journey-client 2.1 parses the legacy resume params itself; the store only forwards a
+ * `journey` query param. This drives that resume path on the inline widget.
+ */
+test('Inline widget resumes a suspended journey from the URL', async ({ page }) => {
+  const suspendedId = 'inline-resume-e2e-suspended-id';
+
+  // Intercept the resume request and return a completed login so the flow terminates.
+  let resumeUrlSeen = null;
+  await page.route('*/**/authenticate?*', async (route, request) => {
+    if (request.url().includes(`suspendedId=${suspendedId}`)) {
+      resumeUrlSeen = request.url();
+      await route.fulfill({
+        json: {
+          tokenId: 'inline-resume-success-token',
+          successUrl: '/openam/console',
+          realm: '/alpha',
+        },
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  // Inline auto-starts resume on mount when a suspendedId is present — no button to click.
+  await Promise.all([
+    page.waitForResponse((response) => response.url().includes(`suspendedId=${suspendedId}`)),
+    page.goto(`widget/inline?journey=TEST_Login&suspendedId=${suspendedId}`, { waitFor: 'load' }),
+  ]);
+
+  // The resume request fired against the suspended URL, exercising the resume() path.
+  expect(resumeUrlSeen).toContain(`suspendedId=${suspendedId}`);
+});

--- a/e2e/tests/widget/inline/widget-inline.webauthn-login.test.js
+++ b/e2e/tests/widget/inline/widget-inline.webauthn-login.test.js
@@ -49,7 +49,7 @@ test('inline widget exposes passkey autofill attributes on the mixed authenticat
 }) => {
   const { navigate } = asyncEvents(page);
 
-  await navigate('widget/inline?journey=TEST_AutofillPasskeyWebAuthn');
+  await navigate('widget/inline?journey=TEST_AutofillPasskeyWebAuthn_autocomplete_conditional');
 
   const usernameInput = page.getByLabel('Username');
 

--- a/e2e/tests/widget/modal/widget-modal.email-suspend.test.js
+++ b/e2e/tests/widget/modal/widget-modal.email-suspend.test.js
@@ -62,3 +62,42 @@ test('Modal widget with email suspend', async ({ page }) => {
   // There should be no submit button within form
   await expect(form.getByRole('button')).not.toBeAttached();
 });
+
+/**
+ * Resume-from-URL: when the page is opened with a suspendedId (as an email magic link
+ * would land the user), the widget calls journey.resume(location.href). journey-client 2.1
+ * parses the legacy resume params itself; the store only forwards a `journey` query param.
+ * This drives that resume path and asserts the resume request carries the suspendedId.
+ */
+test('Modal widget resumes a suspended journey from the URL', async ({ page }) => {
+  const { clickButton } = asyncEvents(page);
+
+  const suspendedId = 'resume-e2e-suspended-id';
+
+  // Intercept the resume request and return a completed login so the flow terminates.
+  let resumeUrlSeen = null;
+  await page.route('*/**/authenticate?*', async (route, request) => {
+    if (request.url().includes(`suspendedId=${suspendedId}`)) {
+      resumeUrlSeen = request.url();
+      await route.fulfill({
+        json: {
+          tokenId: 'resume-success-token',
+          successUrl: '/openam/console',
+          realm: '/alpha',
+        },
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto(`widget/modal?journey=TEST_Login&suspendedId=${suspendedId}`, {
+    waitFor: 'load',
+  });
+
+  // Opening the modal with a suspendedId triggers journey.resume(location.href).
+  await clickButton('Open Login Modal', `suspendedId=${suspendedId}`);
+
+  // The resume request fired against the suspended URL, exercising the resume() path.
+  expect(resumeUrlSeen).toContain(`suspendedId=${suspendedId}`);
+});

--- a/e2e/tests/widget/modal/widget-modal.login-failure.test.js
+++ b/e2e/tests/widget/modal/widget-modal.login-failure.test.js
@@ -1,0 +1,51 @@
+/**
+ *
+ * Copyright © 2026 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ **/
+
+import { expect, test } from '@playwright/test';
+
+import { asyncEvents } from '../../utilities/async-events.js';
+
+/**
+ * Dedicated coverage for the login-failure path. journey-client 2.1 returns a
+ * `LoginFailure` result (instead of a generic error) for AM authentication
+ * failures, which the widget surfaces via the LoginFailure branch of
+ * handleJourneyResult. This test isolates that flow: bad credentials must show
+ * the failure message, fire the failure event, and leave the journey usable.
+ */
+test('Modal widget surfaces a login failure and keeps the journey usable', async ({ page }) => {
+  const { clickButton, navigate } = asyncEvents(page);
+
+  const messageArray = [];
+  page.on('console', (msg) => messageArray.push(msg.text()));
+
+  await navigate('widget/modal?journey=TEST_Login');
+
+  await expect(page.getByRole('dialog')).toBeHidden();
+
+  await clickButton('Open Login Modal', '/authenticate');
+
+  await expect(page.getByRole('dialog')).toBeVisible();
+
+  // Submit invalid credentials — AM responds 4xx and journey-client returns a LoginFailure.
+  await page.getByLabel('Username').fill('notauser');
+  await page.getByLabel('Password').fill('notapassword');
+
+  await clickButton('Sign In', '/authenticate');
+
+  // Failure message renders...
+  await expect(page.getByText('Sign in failed')).toBeVisible();
+
+  // ...the journey onFailure() event fires...
+  expect(messageArray.includes('Login failure event fired')).toBe(true);
+
+  // ...and the journey restarts with a fresh, usable form (not a dead end).
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByLabel('Username')).toBeEditable();
+  await expect(page.getByLabel('Password')).toBeEditable();
+});

--- a/e2e/tests/widget/modal/widget-modal.webauthn-login.test.js
+++ b/e2e/tests/widget/modal/widget-modal.webauthn-login.test.js
@@ -52,7 +52,7 @@ test('modal widget exposes passkey autofill attributes on the mixed authenticati
 }) => {
   const { clickButton, navigate } = asyncEvents(page);
 
-  await navigate('widget/modal?journey=TEST_AutofillPasskeyWebAuthn');
+  await navigate('widget/modal?journey=TEST_AutofillPasskeyWebAuthn_autocomplete_conditional');
   await clickButton('Open Login Modal', '/authenticate');
 
   const usernameInput = page.getByLabel('Username');

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^9.39.2",
     "@forgerock/javascript-sdk": "^4.9.1",
-    "@forgerock/journey-client": "^2.0.0",
+    "@forgerock/journey-client": "^2.1.0",
     "@forgerock/ping-protect": "^4.7.0",
     "@storybook/addon-a11y": "^10.1.11",
     "@storybook/addon-docs": "^10.1.11",

--- a/packages/login-widget/package.json
+++ b/packages/login-widget/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@forgerock/javascript-sdk": "^4.9.1",
-    "@forgerock/journey-client": "^2.0.0",
+    "@forgerock/journey-client": "^2.1.0",
     "@forgerock/ping-protect": "^4.7.1",
     "qrcode": "1.5.3",
     "xss": "^1.0.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^4.9.1
         version: 4.9.1(react@19.2.4)
       '@forgerock/journey-client':
-        specifier: ^2.0.0
-        version: 2.0.0(react@19.2.4)
+        specifier: ^2.1.0
+        version: 2.1.0(react@19.2.4)
       '@forgerock/ping-protect':
         specifier: ^4.7.0
         version: 4.7.1(react@19.2.4)
@@ -250,8 +250,8 @@ importers:
         specifier: ^4.9.1
         version: 4.9.1(react@19.2.4)
       '@forgerock/journey-client':
-        specifier: ^2.0.0
-        version: 2.0.0(react@19.2.4)
+        specifier: ^2.1.0
+        version: 2.1.0(react@19.2.4)
       '@forgerock/ping-protect':
         specifier: ^4.7.1
         version: 4.7.1(react@19.2.4)
@@ -1122,29 +1122,29 @@ packages:
   '@forgerock/javascript-sdk@4.9.1':
     resolution: {integrity: sha512-VVRZ/ZBoghw0CRjzkhk1P1MYe9BPEDSRFhV6Hpq91I5Toqzj8dYGECr2pky/tlMRnkpuhzjYsUCg7QbumG1HYQ==}
 
-  '@forgerock/journey-client@2.0.0':
-    resolution: {integrity: sha512-nwVs+/ybJP/TPkUkaPXM4ThkZMmfae+RiE0dso0g6sW1ST366AVxQqEIxI7C4UJvKDsC+wfjprX5sjVdhlILdw==}
+  '@forgerock/journey-client@2.1.0':
+    resolution: {integrity: sha512-RinYi35EP7Viyhk+vkj8eIhBKwRfLlcEa9yGlLIAfx6xD82V/opWh7eCefPzUMI9HETStl3nydkjN4z+RgbLJg==}
 
   '@forgerock/ping-protect@4.7.1':
     resolution: {integrity: sha512-75SMVWH+cnmcqsRke4cwPhvOqoaNRG+Qm4WKGspx5kUT7qh9q17ZdIq5GoQeAebBvwT4oO+M8nqokc4YuxJXaw==}
 
-  '@forgerock/sdk-logger@2.0.0':
-    resolution: {integrity: sha512-H1MvYXM17v/IvolBdzFxCN1ZUq3+P/IOXBQA93Yma4CEBRzdzOUlusisQjAjsbm0kjTqv77EaW5j73belD0Qcg==}
+  '@forgerock/sdk-logger@2.1.0':
+    resolution: {integrity: sha512-Y0ufMt6E5I+rUO854jvDGnfbZrzUJ0pR5nQL7CHxjlhsODLM7rHBUvOX2ThIOEJF5+25I7YzUWpY4Obbp8BdRg==}
 
-  '@forgerock/sdk-oidc@2.0.0':
-    resolution: {integrity: sha512-5xj1mkvXZzhT0uZD4pGswznq4Ot7fPNtoIm7X5p2k7hoA8yibaoNadHrFmXZPFSGvomKDxbsmvNA6NajDu5nIQ==}
+  '@forgerock/sdk-oidc@2.1.0':
+    resolution: {integrity: sha512-PbXHqNQrc0+DVZQxZRW1XJiizAJxyhGkp6eEsAsDz3BvDa3UkDa6FLV23mLgbOyIospgyfaog+BCVlzaJ8duNw==}
 
-  '@forgerock/sdk-request-middleware@2.0.0':
-    resolution: {integrity: sha512-0ZAV0Lviq662qrPAPHE+RPr7my29hc7n5F6OkNLLW3DONl94+nq3Dl3M5D1fezkfM2bdOQmJPaHwmq/7hwsTYg==}
+  '@forgerock/sdk-request-middleware@2.1.0':
+    resolution: {integrity: sha512-My/U9INW7Mcacf6NqbBcP6xcyOGDhZ1pqhDEJcjcQU5LLo/efUujRkNDNB6hzB4re4kn8R67YZXIby/pTn1DIw==}
 
-  '@forgerock/sdk-types@2.0.0':
-    resolution: {integrity: sha512-my19sUM3noqsEIjktq8Vyf0iOMZir5tbB+y/b6I5pTDRtvTjznW9wHmAjs6Z+SGeJfyj9Un/LaxOXcCH9bYwrA==}
+  '@forgerock/sdk-types@2.1.0':
+    resolution: {integrity: sha512-FAiJrdMLiN5rem8PUBhtCscaft8Fk1X/5XClHSDD7mlClQDj3ARzyMgkXWJ/HhMVzlPcFJnNjg2kZOhsRvVdvw==}
 
-  '@forgerock/sdk-utilities@2.0.0':
-    resolution: {integrity: sha512-nLo9oB6xZbkbdxtQU+sYsb4+jcJv506x0udvlZOdbkfVQe1LgvZzQi6q6jghiXkHZPIJ79Z7DwLOFNiKxTdZGA==}
+  '@forgerock/sdk-utilities@2.1.0':
+    resolution: {integrity: sha512-EdP8sj/EYPNL3sKi8eR+r7QmBC3nkXe0HxhI6K6uVqwrp8ePAPjqFSNHYb+1wU2jYRCu9/qCK6LybaBIz4hWCA==}
 
-  '@forgerock/storage@2.0.0':
-    resolution: {integrity: sha512-0/1AL8s1UUGQov93n2i3KRalIIZ6P/KZ2pGgg3Ki3LpjVej80BGZkMp05WfQ8S74XkM81S+VmUdWUILzhLtaTA==}
+  '@forgerock/storage@2.1.0':
+    resolution: {integrity: sha512-hOy2tGHbw9tCIKwZCWP7JbeoTGZiCvMS4aHlzIgGNlzIkmCrSDXIw2/FZ6vduaJxz7ANB2xnAu6bWprL53ecNg==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -7062,15 +7062,16 @@ snapshots:
       - react
       - react-redux
 
-  '@forgerock/journey-client@2.0.0(react@19.2.4)':
+  '@forgerock/journey-client@2.1.0(react@19.2.4)':
     dependencies:
-      '@forgerock/sdk-logger': 2.0.0
-      '@forgerock/sdk-oidc': 2.0.0
-      '@forgerock/sdk-request-middleware': 2.0.0(react@19.2.4)
-      '@forgerock/sdk-types': 2.0.0
-      '@forgerock/sdk-utilities': 2.0.0
-      '@forgerock/storage': 2.0.0
+      '@forgerock/sdk-logger': 2.1.0
+      '@forgerock/sdk-oidc': 2.1.0
+      '@forgerock/sdk-request-middleware': 2.1.0(react@19.2.4)
+      '@forgerock/sdk-types': 2.1.0
+      '@forgerock/sdk-utilities': 2.1.0
+      '@forgerock/storage': 2.1.0
       '@reduxjs/toolkit': 2.11.2(react@19.2.4)
+      effect: 3.21.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - react
@@ -7083,29 +7084,32 @@ snapshots:
       - react
       - react-redux
 
-  '@forgerock/sdk-logger@2.0.0': {}
-
-  '@forgerock/sdk-oidc@2.0.0':
+  '@forgerock/sdk-logger@2.1.0':
     dependencies:
-      '@forgerock/sdk-types': 2.0.0
-      '@forgerock/sdk-utilities': 2.0.0
+      '@forgerock/sdk-types': 2.1.0
 
-  '@forgerock/sdk-request-middleware@2.0.0(react@19.2.4)':
+  '@forgerock/sdk-oidc@2.1.0':
+    dependencies:
+      '@forgerock/sdk-types': 2.1.0
+      '@forgerock/sdk-utilities': 2.1.0
+
+  '@forgerock/sdk-request-middleware@2.1.0(react@19.2.4)':
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react@19.2.4)
     transitivePeerDependencies:
       - react
       - react-redux
 
-  '@forgerock/sdk-types@2.0.0': {}
+  '@forgerock/sdk-types@2.1.0': {}
 
-  '@forgerock/sdk-utilities@2.0.0':
+  '@forgerock/sdk-utilities@2.1.0':
     dependencies:
-      '@forgerock/sdk-types': 2.0.0
+      '@forgerock/sdk-types': 2.1.0
+      effect: 3.21.0
 
-  '@forgerock/storage@2.0.0':
+  '@forgerock/storage@2.1.0':
     dependencies:
-      '@forgerock/sdk-types': 2.0.0
+      '@forgerock/sdk-types': 2.1.0
 
   '@hapi/hoek@9.3.0': {}
 


### PR DESCRIPTION
# JIRA ticket
https://pingidentity.atlassian.net/browse/SDKS-5213

## Summary

Adopts `@forgerock/journey-client` 2.1 exports and removes the local workarounds it supersedes. Ties to **SDKS-5213** (login-framework QA of the 2.1 beta).

### Type imports (drop local derivations)
- `PolicyParams` — imported from `@forgerock/journey-client/types` instead of deriving `PolicyRequirement['params']`
- `JourneyResult`, `JourneyLoginFailure` — imported instead of local `Awaited<ReturnType<...>>` / `Extract<...>` derivations (in `journey.store.ts`, `step.utilities.ts`, and the test)
- `StepDetail` — imported instead of local `NonNullable<Step['detail']>`
- Removed the associated `// TODO:` comments that tracked these missing exports

### Login-failure handling (#19)
- Removed the `no_response_data` workaround in `handleJourneyResult`. journey-client 2.1 now returns a `LoginFailure` result for AM authentication failures (server-side fix landed in 2.1), so the previously-dormant `LoginFailure` branch now activates. Genuine transport failures still fall through to the network-error message via `GenericError`.

### resume() de-duplication (#18)
- journey-client 2.1 parses the legacy resume URL params itself (`errorCode`, `errorMessage`, `nonce`, `RelayState`, `scope`, `suspendedId`, `authIndexValue`, plus the redirect params). Removed the framework's duplicate parsing.
- Kept the single `?journey=` query-param forward, which journey-client does **not** read from the URL — preserving prior precedence (URL `journey` wins over `resumeOptions.journey`).

## Tests
- **Unit** (`journey.store.test.ts`): LoginFailure branch routing, GenericError branch, resume `?journey=` forwarding (present / absent / precedence-over-options).
- **E2E**: new modal + inline login-failure tests; new inline resume-from-URL test; extended modal email-suspend with a resume block.
- 249 unit tests pass · lint clean.

## ⚠️ Before merge — version bump required
This branch pins the dependency to the **beta** in both `package.json` and `packages/login-widget/package.json`:

```
"@forgerock/journey-client": "0.0.0-beta-20260627000156"
```

Once journey-client **2.1** is published to npm, bump this to the stable release (e.g. `^2.1.0`) and refresh `pnpm-lock.yaml` **before merging**. Do not merge on the beta pin.
