### PR TITLE
chore(security): switch mend check to full repo baseline scan

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -33,7 +33,7 @@
   },
   "checkRunSettings": {
     "vulnerableCheckRunConclusionLevel": "failure",
-    "displayMode": "diff",
+    "displayMode": "baseline",
     "useMendCheckNames": true
   },
   "issueSettings": {


### PR DESCRIPTION
## Summary

Switches the Mend (WhiteSource) security check from diff mode to baseline mode, so PR checks report the full repo vulnerability inventory instead of only new vulnerabilities introduced by the diff.

## Changes

### `.whitesource`

- `checkRunSettings.displayMode` — `"diff"` → `"baseline"`. Only this setting changed; severity thresholds and SAST config untouched.

## Tests

- No automated test surface — this is a scanner config file, not application code.
- Validated the file is still valid JSON after the edit.

## How to test

### 1. Confirm config change

Check `.whitesource` in this PR.`checkRunSettings.displayMode` should read `"baseline"`.

### 2. Verify on a future PR (not this one)

**Important:** Mend reads `.whitesource` from the base branch, not the PR branch. This PR's own Mend check will still run in diff mode ("did not find any new vulnerabilities", "Base branch total remaining vulnerabilities: N") because the base branch config hasn't changed yet. The `baseline` behavior only takes effect once this PR merges — verify it on the next PR opened afterward: the Mend check should report total vulnerabilities across the whole repo instead of a diff-only summary.

Reference: [Mend docs — displayMode / Build Settings](https://docs.mend.io/integrations/latest/install-mend-for-bitbucket-cloud#Build-Settings-(buildSettings))