### PR TITLE
SDKS-5224: Fix Stage Component Generation for PascalCase Names

### DIFF
--- a/.changeset/fix-stage-slug-pascalcase.md
+++ b/.changeset/fix-stage-slug-pascalcase.md
@@ -1,0 +1,5 @@
+---
+'@forgerock/login-framework-cli': patch
+---
+
+Fix `generate stage <Name>` producing incorrect slugs for PascalCase stage names (e.g. `MyCustomStage` → `mycustomstage` instead of `my-custom-stage`). Stage slugs now hyphenate at word and acronym boundaries the same way callback slugs do.

--- a/tools/cli/src/commands/generate.ts
+++ b/tools/cli/src/commands/generate.ts
@@ -16,11 +16,14 @@ const CUSTOM_DIR = 'experimental/custom';
 /**
  * Converts a PascalCase name to a kebab-case slug.
  * Uses two passes to correctly handle acronyms.
- * Examples: "MyCallback" → "my-callback", "JWTLogin" → "jwt-login", "MyURLCallback" → "my-url-callback"
+ * The acronym-boundary pass requires 2+ leading capitals so a single leading capital
+ * (e.g. "OAuth") isn't mistaken for an acronym run and split off on its own.
+ * Examples: "MyCallback" → "my-callback", "JWTLogin" → "jwt-login", "MyURLCallback" → "my-url-callback",
+ * "OAuth2Login" → "oauth2-login"
  */
 function toKebabCase(name: string): string {
   return name
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .replace(/([A-Z]{2,})([A-Z][a-z])/g, '$1-$2')
     .replace(/([a-z\d])([A-Z])/g, '$1-$2')
     .toLowerCase();
 }
@@ -28,11 +31,13 @@ function toKebabCase(name: string): string {
 /**
  * Converts an arbitrary string to a kebab-case directory slug.
  * Used for stage names which may contain spaces, hyphens, or mixed case.
- * Examples: "My Login Stage" → "my-login-stage", "DefaultLogin" → "defaultlogin", "OTP Login" → "otp-login"
+ * Delegates PascalCase/acronym word-boundary splitting to toKebabCase, then normalizes
+ * any remaining separators (spaces, underscores, hyphens) since, unlike callback names,
+ * stage names aren't constrained to alphanumeric PascalCase.
+ * Examples: "My Login Stage" → "my-login-stage", "DefaultLogin" → "default-login", "OTP Login" → "otp-login"
  */
 function toSlug(name: string): string {
-  return name
-    .toLowerCase()
+  return toKebabCase(name)
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 }

--- a/tools/cli/test/generate.test.ts
+++ b/tools/cli/test/generate.test.ts
@@ -146,6 +146,10 @@ describe('CallbackNameSchema', () => {
       expect(decodeCallback('Login').slug).toBe('login');
     });
 
+    it('does not mistake a single leading capital for an acronym run', () => {
+      expect(decodeCallback('OAuth2Login').slug).toBe('oauth2-login');
+    });
+
     it('preserves the original PascalCase name', () => {
       expect(decodeCallback('MyCallback').name).toBe('MyCallback');
     });
@@ -178,7 +182,11 @@ describe('StageNameSchema', () => {
   describe('valid names — AM stage names are arbitrary strings', () => {
     it('accepts PascalCase (common AM convention)', () => {
       expect(decodeStage('DefaultLogin').name).toBe('DefaultLogin');
-      expect(decodeStage('DefaultLogin').slug).toBe('defaultlogin');
+      expect(decodeStage('DefaultLogin').slug).toBe('default-login');
+    });
+
+    it('hyphenates PascalCase stage names at word boundaries', () => {
+      expect(decodeStage('MyCustomStage').slug).toBe('my-custom-stage');
     });
 
     it('accepts names with spaces', () => {
@@ -192,6 +200,15 @@ describe('StageNameSchema', () => {
 
     it('accepts names with mixed separators', () => {
       expect(decodeStage('OTP Login').slug).toBe('otp-login');
+    });
+
+    it('hyphenates acronym runs in PascalCase stage names', () => {
+      expect(decodeStage('JWTLoginStage').slug).toBe('jwt-login-stage');
+    });
+
+    it('handles digit-adjacent acronym boundaries', () => {
+      expect(decodeStage('OAuth2Login').slug).toBe('oauth2-login');
+      expect(decodeStage('SAML2Stage').slug).toBe('saml2-stage');
     });
 
     it('preserves the original name', () => {


### PR DESCRIPTION
## Summary

https://pingidentity.atlassian.net/browse/SDKS-5224

`ping-lf generate stage MyCustomStage` scaffolded files as `mycustomstage.*` instead of `my-custom-stage.*`, while the equivalent callback command slugged correctly. Stage slug generation now shares the callback command's word-boundary logic, so PascalCase, acronym-run, and space-separated stage names all hyphenate consistently.

## Changes

### `tools/cli`

- `toSlug()`: now delegates PascalCase/acronym word-boundary splitting to `toKebabCase()` before normalizing remaining separators (spaces, underscores, hyphens). Previously it only lowercased and replaced non-alphanumerics, collapsing PascalCase input into a single word.
- `toKebabCase()`: acronym-boundary pass tightened from `([A-Z]+)([A-Z][a-z])` to `([A-Z]{2,})([A-Z][a-z])` so a single leading capital (e.g. `OAuth2Login`) isn't treated as an acronym run and split off on its own.
- Single source of truth for word-boundary logic between stage and callback slugs; acronym handling comes for free.

### `.changeset`

- `fix-stage-slug-pascalcase.md`: patch bump for `@forgerock/login-framework-cli`, documenting the slug behavior change.

## Tests

- Added stage-slug cases in `tools/cli/test/generate.test.ts`: PascalCase (`MyCustomStage` to `my-custom-stage`), acronym-run (`JWTLoginStage` to `jwt-login-stage`), digit-adjacent boundaries (`OAuth2Login` to `oauth2-login`, `SAML2Stage` to `saml2-stage`).
- Added a callback-slug regression case for the tightened acronym rule (`decodeCallback('OAuth2Login').slug` to `oauth2-login`).
- Updated `decodeStage('DefaultLogin').slug` expectation from `'defaultlogin'` to `'default-login'`; that assertion encoded the bug.
- Existing space-separated and mixed-case assertions (`My Login Stage`, `OTP Login`) are unchanged and still pass.

## How to test

### 1. Run the unit tests

```sh
pnpm --filter @forgerock/login-framework-cli exec vitest run generate
```

All `StageNameSchema` and `CallbackNameSchema` slug cases should pass.

### 2. Scaffold a PascalCase stage

```sh
pnpm ping-lf generate stage MyCustomStage
```

Expect a `my-custom-stage/` directory with `my-custom-stage.*` files (previously `mycustomstage.*`).

### Verify existing name shapes are unchanged

```sh
pnpm ping-lf generate stage "My Login Stage"    # -> my-login-stage
pnpm ping-lf generate stage "OTP Login"         # -> otp-login
pnpm ping-lf generate callback MyCustomCallback # -> my-custom-callback
```